### PR TITLE
remove tool config files from release artifacts

### DIFF
--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -37,7 +37,7 @@ jobs:
 
             # copy metafiles to repository as well
             -   run: cp -R build/target-repository/. .
-            -   run: rm -rf build .github tests stubs
+            -   run: rm -rf build .github tests stubs ecs.php phpstan.neon phpunit.xml
 
             # setup git user
             -


### PR DESCRIPTION
primary motivation was, that I used the wrong phpstan-config file (since I don't use the extension installer).

the phpstan.neon is only useful when working on this project, so removing it from the release also means people cannot include it by mistake 