### PR TITLE
Skip locally used methods as dead-ones

### DIFF
--- a/src/ClassMethodCallReferenceResolver.php
+++ b/src/ClassMethodCallReferenceResolver.php
@@ -14,7 +14,7 @@ use TomasVotruba\UnusedPublic\ValueObject\MethodCallReference;
 
 final class ClassMethodCallReferenceResolver
 {
-    public function resolve(MethodCall $methodCall, Scope $scope, bool $allowThisType): ?MethodCallReference
+    public function resolve(MethodCall $methodCall, Scope $scope): ?MethodCallReference
     {
         if ($methodCall->name instanceof Expr) {
             return null;
@@ -27,8 +27,9 @@ final class ClassMethodCallReferenceResolver
             $callerType = TypeCombinator::removeNull($callerType);
         }
 
-        if (! $allowThisType && $callerType instanceof ThisType) {
-            return null;
+        // unwrap this type, as method is used
+        if ($callerType instanceof ThisType) {
+            $callerType = $callerType->getStaticObjectType();
         }
 
         if (! $callerType instanceof TypeWithClassName) {

--- a/src/Collectors/MethodCallCollector.php
+++ b/src/Collectors/MethodCallCollector.php
@@ -38,6 +38,10 @@ final class MethodCallCollector implements Collector
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
+        if (! $this->configuration->isUnusedMethodEnabled()) {
+            return null;
+        }
+
         // skip calls in tests, as they are not used in production
         $classReflection = $scope->getClassReflection();
         if ($classReflection instanceof ClassReflection && $classReflection->isSubclassOf(
@@ -46,10 +50,7 @@ final class MethodCallCollector implements Collector
             return null;
         }
 
-        if (! $this->configuration->isUnusedMethodEnabled()) {
-            return null;
-        }
-
+        // unable to resolve method name
         if ($node->name instanceof Expr) {
             return null;
         }

--- a/src/Collectors/MethodCallCollector.php
+++ b/src/Collectors/MethodCallCollector.php
@@ -55,7 +55,7 @@ final class MethodCallCollector implements Collector
             return null;
         }
 
-        $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope, false);
+        $classMethodCallReference = $this->classMethodCallReferenceResolver->resolve($node, $scope);
         if (! $classMethodCallReference instanceof MethodCallReference) {
             return null;
         }

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Controller/SkipControllerMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Controller/SkipControllerMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Controller;
 
 use Symfony\Component\Routing\Annotation\Route;
 

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Controller/SkipNoRoutingControllerMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Controller/SkipNoRoutingControllerMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Interface/InterfaceWithExtraMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Interface/InterfaceWithExtraMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Interface;
 
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source\Contract\MethodRequiredInterface;
 

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Interface/SkipImplementsInterfaceCoveredByContract.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Interface/SkipImplementsInterfaceCoveredByContract.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Interface;
 
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source\Contract\MethodRequiredInterface;
 

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Interface/SkipInterfaceMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Interface/SkipInterfaceMethod.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Interface;
 
 interface SkipInterfaceMethod
 {

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipLocallyUsedPublicMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipLocallyUsedPublicMethod.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
 
-final class LocallyUsedPublicMethod
+final class SkipLocallyUsedPublicMethod
 {
     public function runHere()
     {

--- a/tests/Rules/UnusedPublicClassMethodRule/Source/NullableClassMethodCaller.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Source/NullableClassMethodCaller.php
@@ -12,4 +12,11 @@ final class NullableClassMethodCaller
     {
         $skipNullableUsedPublicMethod->useMeMaybe();
     }
+
+    private function goAgain(?SkipNullableUsedPublicMethod $skipNullableUsedPublicMethod)
+    {
+        if ($skipNullableUsedPublicMethod instanceof SkipNullableUsedPublicMethod) {
+            $skipNullableUsedPublicMethod->useMeMaybe();
+        }
+    }
 }

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -14,7 +14,7 @@ use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Rules\UnusedPublicClassMethodRule;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Interface\InterfaceWithExtraMethod;
-use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\LocallyUsedPublicMethod;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\SkipLocallyUsedPublicMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\StaticPublicMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\UsedInTestCaseOnly;
 
@@ -35,13 +35,7 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
 
     public function provideData(): Iterator
     {
-        $errorMessage = sprintf(
-            UnusedPublicClassMethodRule::ERROR_MESSAGE,
-            LocallyUsedPublicMethod::class,
-            'runHere'
-        );
-        yield [[__DIR__ . '/Fixture/LocallyUsedPublicMethod.php'],
-            [[$errorMessage, 9, RuleTips::SOLUTION_MESSAGE]], ];
+        yield [[__DIR__ . '/Fixture/SkipLocallyUsedPublicMethod.php'], []];
 
         $errorMessage = sprintf(
             UnusedPublicClassMethodRule::ERROR_MESSAGE,

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -60,8 +60,8 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
 
         // public methods expected
         yield [[__DIR__ . '/Fixture/SkipTestPublicMethod.php'], []];
-        yield [[__DIR__ . '/Fixture/SkipControllerMethod.php'], []];
-        yield [[__DIR__ . '/Fixture/SkipNoRoutingControllerMethod.php'], []];
+        yield [[__DIR__ . '/Fixture/Controller/SkipControllerMethod.php'], []];
+        yield [[__DIR__ . '/Fixture/Controller/SkipNoRoutingControllerMethod.php'], []];
 
         // method required by parent
         yield [[__DIR__ . '/Fixture/SkipParentMethodOverride.php'], []];

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -14,7 +14,6 @@ use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Rules\UnusedPublicClassMethodRule;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Interface\InterfaceWithExtraMethod;
-use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\SkipLocallyUsedPublicMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\StaticPublicMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\UsedInTestCaseOnly;
 

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -13,7 +13,7 @@ use TomasVotruba\UnusedPublic\Collectors\PublicClassMethodCollector;
 use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Rules\UnusedPublicClassMethodRule;
-use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\InterfaceWithExtraMethod;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Interface\InterfaceWithExtraMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\LocallyUsedPublicMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\StaticPublicMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\UsedInTestCaseOnly;
@@ -48,7 +48,7 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
             InterfaceWithExtraMethod::class,
             'extraMethod'
         );
-        yield [[__DIR__ . '/Fixture/InterfaceWithExtraMethod.php'],
+        yield [[__DIR__ . '/Fixture/Interface/InterfaceWithExtraMethod.php'],
             [[$errorMessage, 15, RuleTips::SOLUTION_MESSAGE]],
         ];
 
@@ -65,11 +65,11 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
 
         // method required by parent
         yield [[__DIR__ . '/Fixture/SkipParentMethodOverride.php'], []];
-        yield [[__DIR__ . '/Fixture/SkipImplementsInterfaceCoveredByContract.php'], []];
+        yield [[__DIR__ . '/Fixture/Interface/SkipImplementsInterfaceCoveredByContract.php'], []];
 
         yield [[__DIR__ . '/Fixture/SkipClassWithAttribute.php'], []];
         yield [[__DIR__ . '/Fixture/SkipPublicApiClassMethod.php'], []];
-        yield [[__DIR__ . '/Fixture/SkipInterfaceMethod.php'], []];
+        yield [[__DIR__ . '/Fixture/Interface/SkipInterfaceMethod.php'], []];
         yield [[__DIR__ . '/Fixture/SkipPrivateClassMethod.php'], []];
         yield [[__DIR__ . '/Fixture/SkipTwigEntityWithMethods.php'], []];
 


### PR DESCRIPTION
The `runHere()` is now reported as a dead method. It's not true and its removal would break the code.

Instead, it should be skipped and marked as `private`. This PR handle the 1st step :) for next one, a custom rule is coming :+1: 

```php
final class SkipLocallyUsedPublicMethod
{
    // keep me please :)
    public function runHere()
    {
    }

    private function run()
    {
        $this->runHere();
    }
}
```