### PR TITLE
mark parameters as optional

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -1,20 +1,11 @@
 parametersSchema:
     unused_public: structure([
-        methods: bool()
-        local_methods: bool()
-        properties: bool()
-        constants: bool()
-        twig_template_paths: listOf(string())
+        ?methods: bool()
+        ?local_methods: bool()
+        ?properties: bool()
+        ?constants: bool()
+        ?twig_template_paths: listOf(string())
     ])
-
-# default parameters
-parameters:
-    unused_public:
-        methods: false
-        local_methods: false
-        properties: false
-        constants: false
-        twig_template_paths: []
 
 services:
     - TomasVotruba\UnusedPublic\PublicClassMethodMatcher

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -51,6 +51,6 @@ final class Configuration
      */
     public function getTwigTemplatePaths(): array
     {
-        return $this->parameters['twig_template_paths'];
+        return $this->parameters['twig_template_paths'] ?? [];
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -24,11 +24,11 @@ final class Configuration
 
     public function shouldCollectMethods(): bool
     {
-        if ($this->parameters['methods']) {
+        if ($this->isUnusedMethodEnabled()) {
             return true;
         }
 
-        return $this->parameters['local_methods'];
+        return $this->parameters['local_methods'] ?? false;
     }
 
     public function isLocalMethodEnabled(): bool


### PR DESCRIPTION
instead of defining the parameter default values twice (once in the .neon and once in the `Configuration`-class), we just declare them in the `Configuration`-class  as of now.

Also this changes the parameter-schema declaration to mark the parameters as optional.

https://github.com/phpstan/phpstan-src/blob/a5b5090f1e606fce3e17204501c7dcf56a0866b8/src/DependencyInjection/ParametersSchemaExtension.php#L108-L112

this change allows us, to define the extensions parameters from other extensions, which are loaded by the phpstan/extension-installer before unused-public itself is loaded