### PR TITLE
Revert "drop nette/utils dependency (#21)"

### DIFF
--- a/build/target-repository/composer.json
+++ b/build/target-repository/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": "^7.2 || 8.0.*",
         "phpstan/phpstan": "^1.9.3",
+        "nette/utils": "^3.2",
         "webmozart/assert": "^1.11"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": "^8.1",
         "phpstan/phpstan": "^1.9.3",
+        "nette/utils": "^3.2",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {


### PR DESCRIPTION
This reverts commit 71ecd2d7ebce972fd7d8f94af39f3089aafe84b2.

while working in `PossibleTwigMethodCallsProvider`  I realized there is indeed usage of [`nette/utils`](https://github.com/TomasVotruba/unused-public/blob/71ecd2d7ebce972fd7d8f94af39f3089aafe84b2/src/Twig/PossibleTwigMethodCallsProvider.php#L8)

this bug should have been caught by CI.. hmm 🤔 