### PR TITLE
DX: Add composer keywords (#30

### DIFF
--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -3,7 +3,7 @@
     "type": "phpstan-extension",
     "description": "Detect unused public properties, constants and methods in your code",
     "license": "MIT",
-    "keywords": ["dev", "static analysis", "phpstan-extension"],
+    "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^7.2 || 8.0.*",
         "phpstan/phpstan": "^1.9.3",

--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -3,7 +3,7 @@
     "type": "phpstan-extension",
     "description": "Detect unused public properties, constants and methods in your code",
     "license": "MIT",
-    "keywords": ["dev"],
+    "keywords": ["dev", "static analysis", "phpstan-extension"],
     "require": {
         "php": "^7.2 || 8.0.*",
         "phpstan/phpstan": "^1.9.3",

--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -3,6 +3,7 @@
     "type": "phpstan-extension",
     "description": "Detect unused public properties, constants and methods in your code",
     "license": "MIT",
+    "keywords": ["dev"],
     "require": {
         "php": "^7.2 || 8.0.*",
         "phpstan/phpstan": "^1.9.3",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "phpstan-extension",
     "description": "Detect unused public properties, constants and methods in your code",
     "license": "MIT",
+    "keywords": ["dev"],
     "require": {
         "php": "^8.1",
         "phpstan/phpstan": "^1.9.3",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "phpstan-extension",
     "description": "Detect unused public properties, constants and methods in your code",
     "license": "MIT",
-    "keywords": ["dev", "static analysis", "phpstan-extension"],
+    "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.1",
         "phpstan/phpstan": "^1.9.3",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "phpstan-extension",
     "description": "Detect unused public properties, constants and methods in your code",
     "license": "MIT",
-    "keywords": ["dev"],
+    "keywords": ["dev", "static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.1",
         "phpstan/phpstan": "^1.9.3",


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency