### PR TITLE
test methods annotated with `@test`

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -2,11 +2,16 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
 return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->paths([__DIR__ . '/src', __DIR__ . '/tests']);
+
+    $ecsConfig->skip([
+        PhpUnitTestAnnotationFixer::class => 'tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCaseAnnotationMethod.php'
+    ]);
 
     $ecsConfig->sets([
         SetList::COMMON,

--- a/src/Collectors/PublicClassMethodCollector.php
+++ b/src/Collectors/PublicClassMethodCollector.php
@@ -9,6 +9,7 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\MethodReflection;
 use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
 use TomasVotruba\UnusedPublic\PublicClassMethodMatcher;
@@ -49,9 +50,7 @@ final class PublicClassMethodCollector implements Collector
             return null;
         }
 
-        // skip test methods
-        $classMethodName = $node->name->toString();
-        if (str_starts_with($classMethodName, 'test')) {
+        if ($this->isTestMethod($node, $scope)) {
             return null;
         }
 
@@ -92,5 +91,23 @@ final class PublicClassMethodCollector implements Collector
         }
 
         return [$classReflection->getName(), $methodName, $node->getLine()];
+    }
+
+    private function isTestMethod(ClassMethod $node, Scope $scope): bool
+    {
+        $classMethodName = $node->name->toString();
+        if (str_starts_with($classMethodName, 'test')) {
+            return true;
+        }
+
+        $methodReflection = $scope->getClassReflection()->getMethod($classMethodName, $scope);
+        if ($methodReflection !== null
+            && $methodReflection->getDocComment() !== null
+            && str_contains($methodReflection->getDocComment(), '@test')
+        ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Collectors/PublicClassMethodCollector.php
+++ b/src/Collectors/PublicClassMethodCollector.php
@@ -49,6 +49,12 @@ final class PublicClassMethodCollector implements Collector
             return null;
         }
 
+        // skip test methods
+        $classMethodName = $node->name->toString();
+        if (str_starts_with($classMethodName, 'test')) {
+            return null;
+        }
+
         $classReflection = $scope->getClassReflection();
 
         // skip

--- a/src/Collectors/PublicClassMethodCollector.php
+++ b/src/Collectors/PublicClassMethodCollector.php
@@ -49,12 +49,6 @@ final class PublicClassMethodCollector implements Collector
             return null;
         }
 
-        // skip test methods
-        $classMethodName = $node->name->toString();
-        if (str_starts_with($classMethodName, 'test')) {
-            return null;
-        }
-
         $classReflection = $scope->getClassReflection();
 
         // skip

--- a/src/Collectors/PublicClassMethodCollector.php
+++ b/src/Collectors/PublicClassMethodCollector.php
@@ -9,7 +9,6 @@ use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\MethodReflection;
 use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
 use TomasVotruba\UnusedPublic\PublicClassMethodMatcher;
@@ -100,7 +99,12 @@ final class PublicClassMethodCollector implements Collector
             return true;
         }
 
-        $methodReflection = $scope->getClassReflection()->getMethod($classMethodName, $scope);
+        if ($scope->getClassReflection() === null) {
+            return false;
+        }
+
+        $methodReflection = $scope->getClassReflection()
+            ->getMethod($classMethodName, $scope);
         if ($methodReflection !== null
             && $methodReflection->getDocComment() !== null
             && str_contains($methodReflection->getDocComment(), '@test')

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class SkipTestAnnotationMethod extends TestCase
+{
+    /**
+     * @test
+     */
+    public function someMethodAnnotatedTest()
+    {
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
@@ -6,7 +6,7 @@ namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixt
 
 use PHPUnit\Framework\TestCase;
 
-final class SkipTestAnnotationMethod extends TestCase
+final class SkipTestAnnotationMethod
 {
     public function testSomeMethodAnnotatedTest()
     {

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
@@ -6,7 +6,7 @@ namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixt
 
 use PHPUnit\Framework\TestCase;
 
-final class SkipTestAnnotationMethod
+final class SkipTestAnnotationMethod // not extending TestCase
 {
     public function testSomeMethodAnnotatedTest()
     {

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
@@ -8,7 +8,10 @@ use PHPUnit\Framework\TestCase;
 
 final class SkipTestAnnotationMethod // not extending TestCase
 {
-    public function testSomeMethodAnnotatedTest()
+    /**
+     * @test
+     */
+    public function someMethodAnnotatedTest()
     {
     }
 }

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestAnnotationMethod.php
@@ -8,10 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 final class SkipTestAnnotationMethod extends TestCase
 {
-    /**
-     * @test
-     */
-    public function someMethodAnnotatedTest()
+    public function testSomeMethodAnnotatedTest()
     {
     }
 }

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCaseAnnotationMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCaseAnnotationMethod.php
@@ -6,9 +6,9 @@ namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixt
 
 use PHPUnit\Framework\TestCase;
 
-final class SkipTestPublicMethod // not extending TestCase
+final class SkipTestCaseAnnotationMethod extends TestCase
 {
-    public function testSomething()
+    public function testSomeMethodAnnotatedTest()
     {
     }
 }

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCaseAnnotationMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCaseAnnotationMethod.php
@@ -8,7 +8,10 @@ use PHPUnit\Framework\TestCase;
 
 final class SkipTestCaseAnnotationMethod extends TestCase
 {
-    public function testSomeMethodAnnotatedTest()
+    /**
+     * @test
+     */
+    public function someMethodAnnotatedTest()
     {
     }
 }

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCasePublicMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCasePublicMethod.php
@@ -6,7 +6,7 @@ namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixt
 
 use PHPUnit\Framework\TestCase;
 
-final class SkipTestPublicMethod // not extending TestCase
+final class SkipTestCasePublicMethod // not extending TestCase
 {
     public function testSomething()
     {

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCasePublicMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCasePublicMethod.php
@@ -6,7 +6,7 @@ namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixt
 
 use PHPUnit\Framework\TestCase;
 
-final class SkipTestCasePublicMethod // not extending TestCase
+final class SkipTestCasePublicMethod extends TestCase
 {
     public function testSomething()
     {

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -50,6 +50,7 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
 
         // public methods expected
         yield [[__DIR__ . '/Fixture/SkipTestPublicMethod.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipTestCasePublicMethod.php'], []];
         yield [[__DIR__ . '/Fixture/Controller/SkipControllerMethod.php'], []];
         yield [[__DIR__ . '/Fixture/Controller/SkipNoRoutingControllerMethod.php'], []];
 
@@ -84,6 +85,7 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
         ], [[$errorMessage, 9, RuleTips::SOLUTION_MESSAGE]]];
 
         yield [[__DIR__ . '/Fixture/SkipTestAnnotationMethod.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipTestCaseAnnotationMethod.php'], []];
 
         // parent abstract method used by child call
         yield [[

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -83,6 +83,8 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
             __DIR__ . '/Source/TestCaseUser.php',
         ], [[$errorMessage, 9, RuleTips::SOLUTION_MESSAGE]]];
 
+        yield [[__DIR__ . '/Fixture/SkipTestAnnotationMethod.php'], []];
+
         // parent abstract method used by child call
         yield [[
             __DIR__ . '/Fixture/SkipChildUsedPublicMethod.php',


### PR DESCRIPTION
phpunit allows to mark methods with `@test`. these should not be marked as unused.

I think this works already but was just not cover by tests. here we are.

see https://docs.phpunit.de/en/9.5/writing-tests-for-phpunit.html#writing-tests-for-phpunit