### PR TITLE
Skip methods defined on traits

### DIFF
--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -7,7 +7,9 @@ namespace TomasVotruba\UnusedPublic\Rules;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
+use PHPStan\Reflection\Php\PhpMethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Reflection\ResolvedMethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -133,9 +135,12 @@ final class UnusedPublicClassMethodRule implements Rule
             return false;
         }
 
-        $methodReflection = $classReflection->getMethod($methodName, $scope);
+        $extendedMethodReflection = $classReflection->getMethod($methodName, $scope);
+        if ($extendedMethodReflection instanceof PhpMethodReflection || $extendedMethodReflection instanceof ResolvedMethodReflection) {
+            return $extendedMethodReflection->getDeclaringTrait() !== null;
+        }
 
-        return $methodReflection->getDeclaringTrait() !== null;
+        return false;
     }
 
 }

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -70,16 +70,8 @@ final class UnusedPublicClassMethodRule implements Rule
 
         foreach ($publicClassMethodCollector as $filePath => $declarations) {
             foreach ($declarations as [$className, $methodName, $line]) {
-                if ($this->reflectionProvider->hasClass($className)) {
-                    $classReflection = $this->reflectionProvider->getClass($className);
-
-                    if ($classReflection->hasMethod($methodName)) {
-                        $methodReflection = $classReflection->getMethod($methodName, $scope);
-
-                        if ($methodReflection->getDeclaringTrait() !== null) {
-                            continue;
-                        }
-                    }
+                if ($this->isTraitMethod($className, $methodName, $scope)) {
+                    continue;
                 }
 
                 if ($this->isUsedClassMethod(
@@ -129,4 +121,22 @@ final class UnusedPublicClassMethodRule implements Rule
         $methodReference = $className . '::' . $methodName;
         return in_array($methodReference, $completeMethodCallReferences, true);
     }
+
+    private function isTraitMethod(string $className, string $methodName, Scope $scope): bool
+    {
+        if (!$this->reflectionProvider->hasClass($className)) {
+            return false;
+        }
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        if (!$classReflection->hasMethod($methodName)) {
+            return false;
+        }
+
+        $methodReflection = $classReflection->getMethod($methodName, $scope);
+
+        return $methodReflection->getDeclaringTrait() !== null;
+    }
+
 }
+

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -72,10 +72,6 @@ final class UnusedPublicClassMethodRule implements Rule
 
         foreach ($publicClassMethodCollector as $filePath => $declarations) {
             foreach ($declarations as [$className, $methodName, $line]) {
-                if ($this->isTraitMethod($className, $methodName, $scope)) {
-                    continue;
-                }
-
                 if ($this->isUsedClassMethod(
                     $className,
                     $methodName,
@@ -122,25 +118,6 @@ final class UnusedPublicClassMethodRule implements Rule
 
         $methodReference = $className . '::' . $methodName;
         return in_array($methodReference, $completeMethodCallReferences, true);
-    }
-
-    private function isTraitMethod(string $className, string $methodName, Scope $scope): bool
-    {
-        if (!$this->reflectionProvider->hasClass($className)) {
-            return false;
-        }
-        $classReflection = $this->reflectionProvider->getClass($className);
-
-        if (!$classReflection->hasMethod($methodName)) {
-            return false;
-        }
-
-        $extendedMethodReflection = $classReflection->getMethod($methodName, $scope);
-        if ($extendedMethodReflection instanceof PhpMethodReflection || $extendedMethodReflection instanceof ResolvedMethodReflection) {
-            return $extendedMethodReflection->getDeclaringTrait() !== null;
-        }
-
-        return false;
     }
 
 }

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -7,9 +7,6 @@ namespace TomasVotruba\UnusedPublic\Rules;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
-use PHPStan\Reflection\Php\PhpMethodReflection;
-use PHPStan\Reflection\ReflectionProvider;
-use PHPStan\Reflection\ResolvedMethodReflection;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
@@ -38,7 +35,6 @@ final class UnusedPublicClassMethodRule implements Rule
         private readonly TemplateMethodCallsProvider $templateMethodCallsProvider,
         private readonly UsedMethodAnalyzer $usedMethodAnalyzer,
         private readonly MethodCallCollectorMapper $methodCallCollectorMapper,
-        private readonly ReflectionProvider $reflectionProvider,
     ) {
     }
 
@@ -119,6 +115,4 @@ final class UnusedPublicClassMethodRule implements Rule
         $methodReference = $className . '::' . $methodName;
         return in_array($methodReference, $completeMethodCallReferences, true);
     }
-
 }
-

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTraitMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTraitMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source\SomeTrait;
+
+final class SkipTraitMethod
+{
+    use SomeTrait;
+
+    public function testSomething()
+    {
+        $this->useMe(); // used method from trait
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/Source/SomeTrait.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Source/SomeTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source;
+
+trait SomeTrait
+{
+    public function useMe()
+    {
+    }
+
+    public function unusedMethod()
+    {
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -111,6 +111,12 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
             __DIR__ . '/Source/Caller1.php',
             __DIR__ . '/Source/Caller2.php',
         ], [[$errorMessage, 9, RuleTips::SOLUTION_MESSAGE]]];
+
+        // traits
+        yield [[
+            __DIR__ . '/Fixture/SkipTraitMethod.php',
+            __DIR__ . '/Source/SomeTrait.php',
+        ], []];
     }
 
     /**


### PR DESCRIPTION
I think we should not report methods from traits as unused, because the trait is likely be used by several classes and not each of these classes will call all methods defined on said trait.

we cannot remove a method from a trait because one of the classes using the trait does not call it.
it means we get a lot of false positives atm