### PR TITLE
Fix false positive on method name case mismatches

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,7 @@ parameters:
         return_type: 99
         param_type: 99
         property_type: 99
+        # print_suggestions: true
 
     level: 8
 

--- a/src/Rules/LocalOnlyPublicClassMethodRule.php
+++ b/src/Rules/LocalOnlyPublicClassMethodRule.php
@@ -109,7 +109,7 @@ final class LocalOnlyPublicClassMethodRule implements Rule
 
         if (in_array(
             $publicMethodReference,
-            array_map(fn($item) => strtolower($item), $localAndExternalMethodCallReferences->getExternalMethodCallReferences()),
+            array_map(fn(string $item) => strtolower($item), $localAndExternalMethodCallReferences->getExternalMethodCallReferences()),
             true
         )) {
             return false;
@@ -117,7 +117,7 @@ final class LocalOnlyPublicClassMethodRule implements Rule
 
         return in_array(
             $publicMethodReference,
-            array_map(fn($item) => strtolower($item), $localAndExternalMethodCallReferences->getLocalMethodCallReferences()),
+            array_map(fn(string $item) => strtolower($item), $localAndExternalMethodCallReferences->getLocalMethodCallReferences()),
             true
         );
     }

--- a/src/Rules/LocalOnlyPublicClassMethodRule.php
+++ b/src/Rules/LocalOnlyPublicClassMethodRule.php
@@ -106,8 +106,14 @@ final class LocalOnlyPublicClassMethodRule implements Rule
 
         // php method calls are case-insensitive
         $publicMethodReference = strtolower($className . '::' . $methodName);
-        $lowerExternalRefs = array_map(fn(string $item) => strtolower($item), $localAndExternalMethodCallReferences->getExternalMethodCallReferences());
-        $lowerLocalRefs = array_map(fn(string $item) => strtolower($item), $localAndExternalMethodCallReferences->getLocalMethodCallReferences());
+        $lowerExternalRefs = array_map(
+            fn(string $item): string => strtolower($item),
+            $localAndExternalMethodCallReferences->getExternalMethodCallReferences()
+        );
+        $lowerLocalRefs = array_map(
+            fn(string $item): string => strtolower($item),
+            $localAndExternalMethodCallReferences->getLocalMethodCallReferences()
+        );
 
         if (in_array(
             $publicMethodReference,

--- a/src/Rules/LocalOnlyPublicClassMethodRule.php
+++ b/src/Rules/LocalOnlyPublicClassMethodRule.php
@@ -106,10 +106,12 @@ final class LocalOnlyPublicClassMethodRule implements Rule
 
         // php method calls are case-insensitive
         $publicMethodReference = strtolower($className . '::' . $methodName);
+        $lowerExternalRefs = array_map(fn(string $item) => strtolower($item), $localAndExternalMethodCallReferences->getExternalMethodCallReferences());
+        $lowerLocalRefs = array_map(fn(string $item) => strtolower($item), $localAndExternalMethodCallReferences->getLocalMethodCallReferences());
 
         if (in_array(
             $publicMethodReference,
-            array_map(fn(string $item) => strtolower($item), $localAndExternalMethodCallReferences->getExternalMethodCallReferences()),
+            $lowerExternalRefs,
             true
         )) {
             return false;
@@ -117,7 +119,7 @@ final class LocalOnlyPublicClassMethodRule implements Rule
 
         return in_array(
             $publicMethodReference,
-            array_map(fn(string $item) => strtolower($item), $localAndExternalMethodCallReferences->getLocalMethodCallReferences()),
+            $lowerLocalRefs,
             true
         );
     }

--- a/src/Rules/LocalOnlyPublicClassMethodRule.php
+++ b/src/Rules/LocalOnlyPublicClassMethodRule.php
@@ -104,11 +104,12 @@ final class LocalOnlyPublicClassMethodRule implements Rule
             return true;
         }
 
-        $publicMethodReference = $className . '::' . $methodName;
+        // php method calls are case-insensitive
+        $publicMethodReference = strtolower($className . '::' . $methodName);
 
         if (in_array(
             $publicMethodReference,
-            $localAndExternalMethodCallReferences->getExternalMethodCallReferences(),
+            array_map(fn($item) => strtolower($item), $localAndExternalMethodCallReferences->getExternalMethodCallReferences()),
             true
         )) {
             return false;
@@ -116,7 +117,7 @@ final class LocalOnlyPublicClassMethodRule implements Rule
 
         return in_array(
             $publicMethodReference,
-            $localAndExternalMethodCallReferences->getLocalMethodCallReferences(),
+            array_map(fn($item) => strtolower($item), $localAndExternalMethodCallReferences->getLocalMethodCallReferences()),
             true
         );
     }

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -113,7 +113,10 @@ final class UnusedPublicClassMethodRule implements Rule
         }
 
         // php method calls are case-insensitive
-        $lowerCompleteMethodCallReferences = array_map(fn(string $item) => strtolower($item), $completeMethodCallReferences);
+        $lowerCompleteMethodCallReferences = array_map(
+            fn(string $item): string => strtolower($item),
+            $completeMethodCallReferences
+        );
 
         $methodReference = $className . '::' . $methodName;
         return in_array(strtolower($methodReference), $lowerCompleteMethodCallReferences, true);

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -62,9 +62,6 @@ final class UnusedPublicClassMethodRule implements Rule
             $node->get(AttributeCallableCollector::class)
         );
 
-        // php method calls are case-insensitive
-        $completeMethodCallReferences = array_map(fn($item) => strtolower($item), $completeMethodCallReferences);
-
         $publicClassMethodCollector = $node->get(PublicClassMethodCollector::class);
 
         $ruleErrors = [];
@@ -113,6 +110,9 @@ final class UnusedPublicClassMethodRule implements Rule
         if (in_array($methodName, $bladeMethodNames, true)) {
             return true;
         }
+
+        // php method calls are case-insensitive
+        $completeMethodCallReferences = array_map(fn($item) => strtolower($item), $completeMethodCallReferences);
 
         $methodReference = $className . '::' . $methodName;
         return in_array(strtolower($methodReference), $completeMethodCallReferences, true);

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -113,7 +113,7 @@ final class UnusedPublicClassMethodRule implements Rule
         }
 
         // php method calls are case-insensitive
-        $completeMethodCallReferences = array_map(fn($item) => strtolower($item), $completeMethodCallReferences);
+        $completeMethodCallReferences = array_map(fn(string $item) => strtolower($item), $completeMethodCallReferences);
 
         $methodReference = $className . '::' . $methodName;
         return in_array(strtolower($methodReference), $completeMethodCallReferences, true);

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -113,9 +113,9 @@ final class UnusedPublicClassMethodRule implements Rule
         }
 
         // php method calls are case-insensitive
-        $completeMethodCallReferences = array_map(fn(string $item) => strtolower($item), $completeMethodCallReferences);
+        $lowerCompleteMethodCallReferences = array_map(fn(string $item) => strtolower($item), $completeMethodCallReferences);
 
         $methodReference = $className . '::' . $methodName;
-        return in_array(strtolower($methodReference), $completeMethodCallReferences, true);
+        return in_array(strtolower($methodReference), $lowerCompleteMethodCallReferences, true);
     }
 }

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -62,6 +62,9 @@ final class UnusedPublicClassMethodRule implements Rule
             $node->get(AttributeCallableCollector::class)
         );
 
+        // php method calls are case-insensitive
+        $completeMethodCallReferences = array_map(fn($item) => strtolower($item), $completeMethodCallReferences);
+
         $publicClassMethodCollector = $node->get(PublicClassMethodCollector::class);
 
         $ruleErrors = [];
@@ -78,7 +81,6 @@ final class UnusedPublicClassMethodRule implements Rule
                     continue;
                 }
 
-                /** @var string $methodName */
                 $errorMessage = sprintf(self::ERROR_MESSAGE, $className, $methodName);
 
                 $ruleErrors[] = RuleErrorBuilder::message($errorMessage)
@@ -113,6 +115,6 @@ final class UnusedPublicClassMethodRule implements Rule
         }
 
         $methodReference = $className . '::' . $methodName;
-        return in_array($methodReference, $completeMethodCallReferences, true);
+        return in_array(strtolower($methodReference), $completeMethodCallReferences, true);
     }
 }

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -78,6 +78,7 @@ final class UnusedPublicClassMethodRule implements Rule
                     continue;
                 }
 
+                /** @var string $methodName */
                 $errorMessage = sprintf(self::ERROR_MESSAGE, $className, $methodName);
 
                 $ruleErrors[] = RuleErrorBuilder::message($errorMessage)

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/CaseInsensitiveMethodName.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/CaseInsensitiveMethodName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture;
+
+final class CaseInsensitiveMethodName
+{
+    public function runHere()
+    {
+    }
+
+    private function run()
+    {
+        $this->RUNHERE();
+    }
+}

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/CaseInsensitiveMethodName.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/CaseInsensitiveMethodName.php
@@ -12,6 +12,6 @@ final class CaseInsensitiveMethodName
 
     private function run()
     {
-        $this->RUNHERE();
+        $this->RUNHERE(); // intentional wrong case
     }
 }

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/LocalOnlyPublicClassMethodRuleTest.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/LocalOnlyPublicClassMethodRuleTest.php
@@ -15,6 +15,7 @@ use TomasVotruba\UnusedPublic\Collectors\PublicClassMethodCollector;
 use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Rules\LocalOnlyPublicClassMethodRule;
+use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\CaseInsensitiveMethodName;
 use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\LocallyUsedPublicMethod;
 
 final class LocalOnlyPublicClassMethodRuleTest extends RuleTestCase
@@ -36,8 +37,14 @@ final class LocalOnlyPublicClassMethodRuleTest extends RuleTestCase
             LocallyUsedPublicMethod::class,
             'runHere'
         );
-
         yield [[__DIR__ . '/Fixture/LocallyUsedPublicMethod.php'], [[$errorMessage, 9, RuleTips::NARROW_SCOPE]]];
+
+        $errorMessage = sprintf(
+            LocalOnlyPublicClassMethodRule::ERROR_MESSAGE,
+            CaseInsensitiveMethodName::class,
+            'runHere'
+        );
+        yield [[__DIR__ . '/Fixture/CaseInsensitiveMethodName.php'], [[$errorMessage, 9, RuleTips::NARROW_SCOPE]]];
     }
 
     /**

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/CaseInsensitiveMethodName.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/CaseInsensitiveMethodName.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source\Caller1;
+
+final class CaseInsensitiveMethodName
+{
+    public function testWrongCasing(Caller1 $caller1)
+    {
+        $caller1->CALLIT(); // intentional wrong case
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -129,6 +129,12 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
             [$errorMessage1, 9, RuleTips::SOLUTION_MESSAGE],
             [$errorMessage2, 13, RuleTips::SOLUTION_MESSAGE],
         ]];
+
+        yield [[
+            __DIR__ . '/Fixture/CaseInsensitiveMethodName.php',
+            __DIR__ . '/Source/Caller1.php',
+        ], []];
+
     }
 
     /**


### PR DESCRIPTION
PHPs method calls are case insensitive.

before this PR method calls were only be detected properly when the call-site had the very exact same spelling as the declaration.
with this PR I am adjusting it to be case-insensitive