### PR TITLE
Skip properties annotated `@api`

### DIFF
--- a/src/ApiDocStmtAnalyzer.php
+++ b/src/ApiDocStmtAnalyzer.php
@@ -25,6 +25,11 @@ final class ApiDocStmtAnalyzer
             return false;
         }
 
-        return str_contains($docComment->getText(), '@api');
+        return $this->isApiDocComment($docComment->getText());
+
+    }
+
+    public function isApiDocComment(string $docComment) :bool {
+        return str_contains($docComment, '@api');
     }
 }

--- a/src/Collectors/PublicPropertyCollector.php
+++ b/src/Collectors/PublicPropertyCollector.php
@@ -69,6 +69,10 @@ final class PublicPropertyCollector implements Collector
             }
 
             foreach ($property->props as $propertyProperty) {
+                if ($this->apiDocStmtAnalyzer->isApiDoc($propertyProperty, $classReflection)) {
+                    continue;
+                }
+
                 $publicPropertyNames[] = [
                     $classReflection->getName(),
                     $propertyProperty->name->toString(),

--- a/src/Collectors/PublicPropertyCollector.php
+++ b/src/Collectors/PublicPropertyCollector.php
@@ -68,10 +68,12 @@ final class PublicPropertyCollector implements Collector
                 continue;
             }
 
+            if ($this->apiDocStmtAnalyzer->isApiDoc($property, $classReflection)) {
+                continue;
+            }
+
             foreach ($property->props as $propertyProperty) {
-                if ($this->apiDocStmtAnalyzer->isApiDoc($propertyProperty, $classReflection)) {
-                    continue;
-                }
+
 
                 $publicPropertyNames[] = [
                     $classReflection->getName(),

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/IgnoresPrivateApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/IgnoresPrivateApiProperty.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\BasePrivatePropertyClass;
+
+final class IgnoresPrivateApiProperty extends BasePrivatePropertyClass
+{
+    public $property = 'overridden!';
+}
+
+

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/IgnoresPrivateApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/IgnoresPrivateApiProperty.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
 
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\BasePrivatePropertyClass;
 

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedProtectedApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedProtectedApiProperty.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
 
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\BaseProtectedPropertyClass;
 

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedProtectedApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedProtectedApiProperty.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\BaseProtectedPropertyClass;
+
+final class SkipInheritedApiPublicPublicProperty extends BaseProtectedPropertyClass
+{
+    public $property = 'overridden!';
+}
+
+

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
@@ -6,9 +6,6 @@ namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixtu
 
 final class SkipInheritedApiPublicProperty extends BasePropertyClass
 {
-    /**
-     * @api
-     */
     public $property = 'overridden!';
 }
 

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
 
-use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\BasePropertyClass;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\BasePublicPropertyClass;
 
-final class SkipInheritedApiPublicProperty extends BasePropertyClass
+final class SkipInheritedApiPublicPublicProperty extends BasePublicPropertyClass
 {
     public $property = 'overridden!';
 }

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
@@ -4,15 +4,11 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
 
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\BasePropertyClass;
+
 final class SkipInheritedApiPublicProperty extends BasePropertyClass
 {
     public $property = 'overridden!';
 }
 
 
-class BasePropertyClass {
-    /**
-     * @api
-     */
-    public $property = 'paths';
-}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+final class SkipInheritedApiPublicProperty extends BasePropertyClass
+{
+    /**
+     * @api
+     */
+    public $property = 'overridden!';
+}
+
+
+class BasePropertyClass {
+    /**
+     * @api
+     */
+    public $property = 'paths';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipInheritedPublicApiProperty.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
 
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\BasePublicPropertyClass;
 

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipPublicApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipPublicApiProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+final class SkipPublicApiProperty
+{
+    /**
+     * @api
+     */
+    public $property = 'overridden!';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipPublicApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipPublicApiProperty.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
 
 final class SkipPublicApiProperty
 {

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipPublicApiProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/SkipPublicApiProperty.php
@@ -9,5 +9,5 @@ final class SkipPublicApiProperty
     /**
      * @api
      */
-    public $property = 'overridden!';
+    public $property = 'default';
 }

--- a/tests/Rules/UnusedPublicPropertyRule/Source/BasePrivatePropertyClass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/BasePrivatePropertyClass.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
 
-class BasePropertyClass {
+class BasePrivatePropertyClass {
     /**
      * @api
      */
-    public $property = 'paths';
+    private $property = 'private';
 }

--- a/tests/Rules/UnusedPublicPropertyRule/Source/BasePropertyClass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/BasePropertyClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class BasePropertyClass {
+    /**
+     * @api
+     */
+    public $property = 'paths';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Source/BaseProtectedPropertyClass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/BaseProtectedPropertyClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class BaseProtectedPropertyClass {
+    /**
+     * @api
+     */
+    protected $property = 'protected';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Source/BasePublicPropertyClass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/BasePublicPropertyClass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class BasePublicPropertyClass {
+    /**
+     * @api
+     */
+    public $property = 'public';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -14,7 +14,7 @@ use TomasVotruba\UnusedPublic\Collectors\PublicPropertyFetchCollector;
 use TomasVotruba\UnusedPublic\Collectors\PublicStaticPropertyFetchCollector;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Rules\UnusedPublicPropertyRule;
-use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\IgnoresPrivateApiProperty;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\IgnoresPrivateApiProperty;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocallyUsedStaticProperty;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocalyUsedPublicProperty;
 
@@ -74,6 +74,7 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipInheritedPublicApiProperty.php'], []];
         yield [[__DIR__ . '/Fixture/SkipInheritedProtectedApiProperty.php'], []];
         yield [[__DIR__ . '/Fixture/SkipPublicApiProperty.php'], []];
+
         $errorMessage = sprintf(
             UnusedPublicPropertyRule::ERROR_MESSAGE,
             IgnoresPrivateApiProperty::class,

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -14,6 +14,7 @@ use TomasVotruba\UnusedPublic\Collectors\PublicPropertyFetchCollector;
 use TomasVotruba\UnusedPublic\Collectors\PublicStaticPropertyFetchCollector;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Rules\UnusedPublicPropertyRule;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\IgnoresPrivateApiProperty;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocallyUsedStaticProperty;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocalyUsedPublicProperty;
 
@@ -71,7 +72,17 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
         ];
 
         yield [[__DIR__ . '/Fixture/SkipInheritedPublicApiProperty.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipInheritedProtectedApiProperty.php'], []];
         yield [[__DIR__ . '/Fixture/SkipPublicApiProperty.php'], []];
+        $errorMessage = sprintf(
+            UnusedPublicPropertyRule::ERROR_MESSAGE,
+            IgnoresPrivateApiProperty::class,
+            'property'
+        );
+        yield [
+            [__DIR__ . '/Fixture/IgnoresPrivateApiProperty.php'],
+            [[$errorMessage, 9, RuleTips::SOLUTION_MESSAGE]],
+        ];
     }
 
     /**

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -69,6 +69,9 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
             ],
             [],
         ];
+
+        yield [[__DIR__ . '/Fixture/SkipInheritedPublicApiProperty.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipPublicApiProperty.php'], []];
     }
 
     /**


### PR DESCRIPTION
this PR achieves 2 things:
- don't error on public properties annotated with `@api`
- don't error on properties without annotation, when they inherit a phpdoc from a same named public or protected property from the baseclass