### PR TITLE
Improve analyzing speed

### DIFF
--- a/src/Rules/UnusedPublicClassConstRule.php
+++ b/src/Rules/UnusedPublicClassConstRule.php
@@ -59,6 +59,8 @@ final class UnusedPublicClassConstRule implements Rule
         $classConstFetchCollector = $node->get(ClassConstFetchCollector::class);
         $publicClassLikeConstCollector = $node->get(PublicClassLikeConstCollector::class);
 
+        $usedConstFetches = Arrays::flatten($classConstFetchCollector);
+
         $ruleErrors = [];
 
         foreach ($publicClassLikeConstCollector as $filePath => $declarationsGroups) {
@@ -67,7 +69,7 @@ final class UnusedPublicClassConstRule implements Rule
                     if ($this->isClassConstantUsed(
                         $className,
                         $constantName,
-                        $classConstFetchCollector,
+                        $usedConstFetches,
                         $bladeConstFetchNames
                     )) {
                         continue;
@@ -105,7 +107,6 @@ final class UnusedPublicClassConstRule implements Rule
 
         $publicConstantReference = $className . '::' . $constantName;
 
-        $usedConstFetches = Arrays::flatten($usedConstFetches);
         return in_array($publicConstantReference, $usedConstFetches, true);
     }
 }

--- a/src/Rules/UnusedPublicPropertyRule.php
+++ b/src/Rules/UnusedPublicPropertyRule.php
@@ -52,13 +52,14 @@ final class UnusedPublicPropertyRule implements Rule
         $publicStaticPropertyFetchCollector = $node->get(PublicStaticPropertyFetchCollector::class);
 
         $publicPropertyFetchCollector = [...$publicPropertyFetchCollector, ...$publicStaticPropertyFetchCollector];
+        $usedProperties = Arrays::flatten($publicPropertyFetchCollector);
 
         $ruleErrors = [];
 
         foreach ($publicPropertyCollector as $filePath => $declarationsGroups) {
             foreach ($declarationsGroups as $declarationGroup) {
                 foreach ($declarationGroup as [$className, $propertyName, $line]) {
-                    if ($this->isPropertyUsed($className, $propertyName, $publicPropertyFetchCollector)) {
+                    if ($this->isPropertyUsed($className, $propertyName, $usedProperties)) {
                         continue;
                     }
 
@@ -83,7 +84,6 @@ final class UnusedPublicPropertyRule implements Rule
     private function isPropertyUsed(string $className, string $constantName, array $usedProperties): bool
     {
         $publicPropertyReference = $className . '::' . $constantName;
-        $usedProperties = Arrays::flatten($usedProperties);
 
         return in_array($publicPropertyReference, $usedProperties, true);
     }


### PR DESCRIPTION
**based on the latest stable release** I was able to measure a perf improvement of 84%

![grafik](https://user-images.githubusercontent.com/120441/232065635-7a74d57a-f150-4b27-8ba6-99b272c6aedb.png)

on a codebae with ~2500 files

---

before this PR `Arrays::flatten` was taking a considerable amount of the overall time:

![grafik](https://user-images.githubusercontent.com/120441/232065992-72fc202c-e20c-4ba3-94f7-0ddb5d9c7892.png)
