### PR TITLE
Cover case-insensitive classnames with test

### DIFF
--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/CaseInsensitiveClassName.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/CaseInsensitiveClassName.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source\Caller1;
+
+final class CaseInsensitiveClassName
+{
+    public function testWrongCasing(CALLER1 $caller1) // intentional wrong case
+    {
+        $caller1->callIt();
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -137,6 +137,10 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
             __DIR__ . '/Fixture/CaseInsensitiveMethodName.php',
             __DIR__ . '/Source/Caller1.php',
         ], []];
+        yield [[
+            __DIR__ . '/Fixture/CaseInsensitiveClassName.php',
+            __DIR__ . '/Source/Caller1.php',
+        ], []];
 
     }
 


### PR DESCRIPTION
just adding another test-case. the underlying problem was already fixed with https://github.com/TomasVotruba/unused-public/pull/45