### PR TITLE
Support method calls via subclasses

### DIFF
--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipInheritedMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipInheritedMethod.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+class MyBaseClass {
+    public function usedMethod() {}
+
+    /**
+     * @return self|false
+     */
+    static public function getIt()
+    {
+    }
+}
+
+class MySubClass extends MyBaseClass {
+
+}
+
+function doFoo() {
+    $obj = MySubClass::getIt();
+    $obj->usedMethod();
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -142,6 +142,9 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
             __DIR__ . '/Source/Caller1.php',
         ], []];
 
+        yield [[
+            __DIR__ . '/Fixture/SkipInheritedMethod.php',
+        ], []];
     }
 
     /**


### PR DESCRIPTION
I think the test should not fail, because the methods are called via subclass.