### PR TITLE
Skip Symfony data_class in forms

### DIFF
--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -6,7 +6,7 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^7.2 || 8.0.*",
-        "phpstan/phpstan": "^1.9.3",
+        "phpstan/phpstan": "^1.10.19",
         "nette/utils": "^3.2",
         "webmozart/assert": "^1.11"
     },

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.10.0",
+        "phpstan/phpstan": "^1.10.19",
         "nette/utils": "^3.2",
         "webmozart/assert": "^1.11"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "tracy/tracy": "^2.9",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "tomasvotruba/type-coverage": "^0.1",
-        "symplify/easy-ci": "^11.2"
+        "symplify/easy-ci": "^11.2",
+        "symfony/form": "^6.3"
     },
     "autoload": {
         "psr-4": {

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -51,6 +51,11 @@ services:
             - phpstan.collector
 
     -
+        class: TomasVotruba\UnusedPublic\Collectors\FormTypeClassCollector
+        tags:
+            - phpstan.collector
+
+    -
         class: TomasVotruba\UnusedPublic\Collectors\PublicStaticPropertyFetchCollector
         tags:
             - phpstan.collector

--- a/src/Collectors/FormTypeClassCollector.php
+++ b/src/Collectors/FormTypeClassCollector.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Collectors;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Collector;
+use PHPStan\Type\Constant\ConstantStringType;
+use TomasVotruba\UnusedPublic\Configuration;
+
+/**
+ * Match Symfony data_class element in forms types, as those use magic setters/getters
+ * @implements Collector<ArrayItem, array<string>|null>
+ */
+final class FormTypeClassCollector implements Collector
+{
+    public function __construct(
+        private readonly Configuration $configuration,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return ArrayItem::class;
+    }
+
+    /**
+     * @param ArrayItem $node
+     * @return string[]|null
+     */
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        if (! $this->configuration->shouldCollectMethods()) {
+            return null;
+        }
+
+        if (! $node->key instanceof String_) {
+            return null;
+        }
+
+        if ($node->key->value !== 'data_class') {
+            return null;
+        }
+
+        $valueType = $scope->getType($node->value);
+        if (! $valueType instanceof ConstantStringType) {
+            return null;
+        }
+
+        return [$valueType->getValue()];
+    }
+}

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Rules;
 
+use Nette\Utils\Arrays;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
@@ -13,6 +14,7 @@ use PHPStan\Rules\RuleErrorBuilder;
 use TomasVotruba\UnusedPublic\CollectorMapper\MethodCallCollectorMapper;
 use TomasVotruba\UnusedPublic\Collectors\AttributeCallableCollector;
 use TomasVotruba\UnusedPublic\Collectors\CallUserFuncCollector;
+use TomasVotruba\UnusedPublic\Collectors\FormTypeClassCollector;
 use TomasVotruba\UnusedPublic\Collectors\MethodCallCollector;
 use TomasVotruba\UnusedPublic\Collectors\PublicClassMethodCollector;
 use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
@@ -64,6 +66,8 @@ final class UnusedPublicClassMethodRule implements Rule
             $node->get(CallUserFuncCollector::class)
         );
 
+        $formTypeClasses = Arrays::flatten($node->get(FormTypeClassCollector::class));
+
         $publicClassMethodCollector = $node->get(PublicClassMethodCollector::class);
         // php method calls are case-insensitive
         $lowerCompleteMethodCallReferences = array_map(
@@ -75,6 +79,10 @@ final class UnusedPublicClassMethodRule implements Rule
 
         foreach ($publicClassMethodCollector as $filePath => $declarations) {
             foreach ($declarations as [$className, $methodName, $line]) {
+                if (in_array($className, $formTypeClasses, true)) {
+                    continue;
+                }
+
                 if ($this->isUsedClassMethod(
                     $className,
                     $methodName,

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Symfony/SkipEntityGetterSetters.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Symfony/SkipEntityGetterSetters.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Symfony;
+
+class SkipEntityGetterSetters
+{
+    public function getValue()
+    {
+    }
+
+    public function setValue()
+    {
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Symfony/SkipEntityGetterSetters.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Symfony/SkipEntityGetterSetters.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Symfony;
 
 class SkipEntityGetterSetters

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Symfony/SomeFormType.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Symfony/SomeFormType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Symfony;
 
 use Symfony\Component\Form\AbstractType;

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/Symfony/SomeFormType.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/Symfony/SomeFormType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Symfony;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class SomeFormType extends AbstractType
+{
+    public function configureOptions(OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->setDefaults([
+            'data_class' => SkipEntityGetterSetters::class,
+        ]);
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -38,6 +38,10 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
     {
         yield [[__DIR__ . '/Fixture/Symfony/SkipRequiredMethodCall.php'], []];
 
+        yield [[
+            __DIR__ . '/Fixture/Symfony/SomeFormType.php',
+            __DIR__ . '/Fixture/Symfony/SkipEntityGetterSetters.php',
+        ], []];
 
         yield [[__DIR__ . '/Fixture/SkipSymfonyValidatorMethod.php'], []];
         yield [[__DIR__ . '/Fixture/SkipLocallyUsedPublicMethod.php'], []];

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -37,6 +37,8 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
     public static function provideData(): Iterator
     {
         yield [[__DIR__ . '/Fixture/Symfony/SkipRequiredMethodCall.php'], []];
+
+
         yield [[__DIR__ . '/Fixture/SkipSymfonyValidatorMethod.php'], []];
         yield [[__DIR__ . '/Fixture/SkipLocallyUsedPublicMethod.php'], []];
 

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -11,6 +11,7 @@ use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use TomasVotruba\UnusedPublic\Collectors\AttributeCallableCollector;
 use TomasVotruba\UnusedPublic\Collectors\CallUserFuncCollector;
+use TomasVotruba\UnusedPublic\Collectors\FormTypeClassCollector;
 use TomasVotruba\UnusedPublic\Collectors\MethodCallCollector;
 use TomasVotruba\UnusedPublic\Collectors\PublicClassMethodCollector;
 use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
@@ -157,6 +158,7 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
             self::getContainer()->getByType(StaticMethodCallCollector::class),
             self::getContainer()->getByType(AttributeCallableCollector::class),
             self::getContainer()->getByType(CallUserFuncCollector::class),
+            self::getContainer()->getByType(FormTypeClassCollector::class),
         ];
     }
 


### PR DESCRIPTION
Classes, that are used in `"data_class"` elements should be skipped, because they use Symfony magic form getters/setters

```php
<?php

declare(strict_types=1);

namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Symfony;

use Symfony\Component\Form\AbstractType;
use Symfony\Component\OptionsResolver\OptionsResolver;

final class SomeFormType extends AbstractType
{
    public function configureOptions(OptionsResolver $optionsResolver): void
    {
        $optionsResolver->setDefaults([
            'data_class' => SkipEntityGetterSetters::class,
        ]);
    }
}
```