### PR TITLE
extracted `ClassTypeDetector` to ease re-use

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -21,6 +21,7 @@ parameters:
 
 services:
     - TomasVotruba\UnusedPublic\PublicClassMethodMatcher
+    - TomasVotruba\UnusedPublic\ClassTypeDetector
     - TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer
     - TomasVotruba\UnusedPublic\ClassMethodCallReferenceResolver
     - TomasVotruba\UnusedPublic\CollectorMapper\MethodCallCollectorMapper

--- a/src/ClassTypeDetector.php
+++ b/src/ClassTypeDetector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Reflection\ResolvedMethodReflection;
+
+final class ClassTypeDetector
+{
+    public function isTestClass(ClassReflection $classReflection): bool
+    {
+        return $classReflection->isSubclassOf('PHPUnit\Framework\TestCase') || $classReflection->isSubclassOf(
+                'PHPUnit_Framework_TestCase'
+        );
+    }
+
+}

--- a/src/Collectors/CallUserFuncCollector.php
+++ b/src/Collectors/CallUserFuncCollector.php
@@ -11,6 +11,7 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\Constant\ConstantArrayType;
+use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
@@ -20,6 +21,7 @@ final class CallUserFuncCollector implements Collector
 {
     public function __construct(
         private readonly Configuration $configuration,
+        private readonly ClassTypeDetector $classTypeDetector,
     ) {
     }
 
@@ -38,12 +40,12 @@ final class CallUserFuncCollector implements Collector
             return null;
         }
 
-        // skip calls in tests, as they are not used in production
         $classReflection = $scope->getClassReflection();
-        if ($classReflection instanceof ClassReflection && $classReflection->isSubclassOf(
-            'PHPUnit\Framework\TestCase'
-        )) {
-            return null;
+        if ($classReflection instanceof ClassReflection) {
+            // skip calls in tests, as they are not used in production
+            if ($this->classTypeDetector->isTestClass($classReflection)) {
+                return null;
+            }
         }
 
         // unable to resolve method name

--- a/src/PublicClassMethodMatcher.php
+++ b/src/PublicClassMethodMatcher.php
@@ -14,14 +14,21 @@ final class PublicClassMethodMatcher
      * @var string[]
      */
     private const SKIPPED_TYPES = [
-        'PHPUnit\Framework\TestCase',
         'Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator',
     ];
+
+    public function __construct(
+        private readonly ClassTypeDetector $classTypeDetector,
+    ) {}
 
     public function shouldSkipClassReflection(ClassReflection $classReflection): bool
     {
         // skip interface as required, traits as unable to detect for sure
         if ($classReflection->isInterface() || $classReflection->isTrait()) {
+            return true;
+        }
+
+        if ($this->classTypeDetector->isTestClass($classReflection)) {
             return true;
         }
 


### PR DESCRIPTION
preparation for https://github.com/TomasVotruba/unused-public/issues/49

also fixes compat with older phpunit versions when `PHPUnit_Framework_TestCase` is used