### PR TITLE
Added test-case covering property referenced via "static" keyword

### DIFF
--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/LocallyUsedStaticPropertyViaStatic.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/LocallyUsedStaticPropertyViaStatic.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+class LocallyUsedStaticPropertyViaStatic
+{
+    public static $somePublicStaticProperty;
+
+    private function run()
+    {
+        return static::$somePublicStaticProperty;
+    }
+}

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -16,6 +16,7 @@ use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Rules\UnusedPublicPropertyRule;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\IgnoresPrivateApiProperty;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocallyUsedStaticProperty;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocallyUsedStaticPropertyViaStatic;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocalyUsedPublicProperty;
 
 final class UnusedPublicPropertyRuleTest extends RuleTestCase
@@ -48,6 +49,16 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
         );
         yield [
             [__DIR__ . '/Fixture/LocallyUsedStaticProperty.php'],
+            [[$errorMessage, 7, RuleTips::SOLUTION_MESSAGE]],
+        ];
+
+        $errorMessage = sprintf(
+            UnusedPublicPropertyRule::ERROR_MESSAGE,
+            LocallyUsedStaticPropertyViaStatic::class,
+            'somePublicStaticProperty'
+        );
+        yield [
+            [__DIR__ . '/Fixture/LocallyUsedStaticPropertyViaStatic.php'],
             [[$errorMessage, 7, RuleTips::SOLUTION_MESSAGE]],
         ];
 


### PR DESCRIPTION
Initially I added this new test-case, as I was sure when looking at the implementation that it would fail.

turns out it passes, and I don't know why. but as it works as expected lets add this test-coverage :)