### PR TITLE
Implement ProtectedMethodInFinalClassRule

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -97,3 +97,4 @@ rules:
     - TomasVotruba\UnusedPublic\Rules\UnusedPublicClassConstRule
     - TomasVotruba\UnusedPublic\Rules\UnusedPublicPropertyRule
     - TomasVotruba\UnusedPublic\Rules\LocalOnlyPublicClassMethodRule
+    - TomasVotruba\UnusedPublic\Rules\ProtectedMethodInFinalClassRule

--- a/ecs.php
+++ b/ecs.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
+use PhpCsFixer\Fixer\ClassNotation\ProtectedToPrivateFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
 
@@ -10,7 +11,8 @@ return static function (ECSConfig $ecsConfig): void {
     $ecsConfig->paths([__DIR__ . '/src', __DIR__ . '/tests']);
 
     $ecsConfig->skip([
-        PhpUnitTestAnnotationFixer::class => 'tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCaseAnnotationMethod.php'
+        PhpUnitTestAnnotationFixer::class => 'tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipTestCaseAnnotationMethod.php',
+        ProtectedToPrivateFixer::class => 'tests/Rules/ProtectedClassMethodInFinalClassRule/*'
     ]);
 
     $ecsConfig->sets([

--- a/src/ClassTypeDetector.php
+++ b/src/ClassTypeDetector.php
@@ -4,20 +4,14 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic;
 
-use PhpParser\Comment\Doc;
-use PhpParser\Node\Stmt\ClassMethod;
-use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Reflection\Php\PhpMethodReflection;
-use PHPStan\Reflection\ResolvedMethodReflection;
 
 final class ClassTypeDetector
 {
     public function isTestClass(ClassReflection $classReflection): bool
     {
         return $classReflection->isSubclassOf('PHPUnit\Framework\TestCase') || $classReflection->isSubclassOf(
-                'PHPUnit_Framework_TestCase'
+            'PHPUnit_Framework_TestCase'
         );
     }
-
 }

--- a/src/MethodTypeDetector.php
+++ b/src/MethodTypeDetector.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic;
 
-use PhpParser\Comment\Doc;
 use PhpParser\Node\Stmt\ClassMethod;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\ClassReflection;

--- a/src/PublicClassMethodMatcher.php
+++ b/src/PublicClassMethodMatcher.php
@@ -19,7 +19,8 @@ final class PublicClassMethodMatcher
 
     public function __construct(
         private readonly ClassTypeDetector $classTypeDetector,
-    ) {}
+    ) {
+    }
 
     public function shouldSkipClassReflection(ClassReflection $classReflection): bool
     {

--- a/src/Rules/ProtectedMethodInFinalClassRule.php
+++ b/src/Rules/ProtectedMethodInFinalClassRule.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Rules;
+
+use Nette\Utils\Arrays;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\ClassMethod;
+use PHPStan\Node\CollectedDataNode;
+use PHPStan\Node\InClassMethodNode;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleError;
+use PHPStan\Rules\RuleErrorBuilder;
+use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
+use TomasVotruba\UnusedPublic\CollectorMapper\MethodCallCollectorMapper;
+use TomasVotruba\UnusedPublic\Collectors\AttributeCallableCollector;
+use TomasVotruba\UnusedPublic\Collectors\CallUserFuncCollector;
+use TomasVotruba\UnusedPublic\Collectors\FormTypeClassCollector;
+use TomasVotruba\UnusedPublic\Collectors\MethodCallCollector;
+use TomasVotruba\UnusedPublic\Collectors\PublicClassMethodCollector;
+use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
+use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\Enum\RuleTips;
+use TomasVotruba\UnusedPublic\Templates\TemplateMethodCallsProvider;
+use TomasVotruba\UnusedPublic\Templates\UsedMethodAnalyzer;
+
+/**
+ * @see \TomasVotruba\UnusedPublic\Tests\Rules\ProtectedClassMethodInFinalClassRule\ProtectedClassMethodInFinalClassRuleTest
+ */
+final class ProtectedMethodInFinalClassRule implements Rule
+{
+    /**
+     * @var string
+     */
+    public const ERROR_MESSAGE = 'Protected method "%s" should be reduced to private visiblity';
+
+    public function __construct(
+        private readonly ApiDocStmtAnalyzer       $apiDocStmtAnalyzer,
+    ) {}
+
+    public function getNodeType(): string
+    {
+        return InClassMethodNode::class;
+    }
+
+    /**
+     * @param InClassMethodNode $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $methodReflection = $node->getMethodReflection();
+        $method = $node->getOriginalNode();
+
+        if (!$method->isProtected()) {
+            return [];
+        }
+
+        $classReflection = $scope->getClassReflection();
+        if ($classReflection === null) {
+            return [];
+        }
+
+        if (!$classReflection->isFinal()) {
+            return[];
+        }
+
+        $docComment = $methodReflection->getDocComment();
+        if ($docComment !== null && $this->apiDocStmtAnalyzer->isApiDocComment($docComment)) {
+            return [];
+        }
+
+        $methodName = $methodReflection->getName();
+        if (!$classReflection->hasMethod($methodName)) {
+            return [];
+        }
+
+        $parentClass = $classReflection->getParentClass();
+        while($parentClass !== null) {
+            // method is overridding a parent method, which might be called from the base-class
+            if ($parentClass->hasMethod($methodName)) {
+                return [];
+            }
+
+            $parentClass = $parentClass->getParentClass();
+        }
+
+        return [RuleErrorBuilder::message(
+            sprintf(self::ERROR_MESSAGE, $methodName)
+        )->build()];
+    }
+
+}

--- a/src/Rules/ProtectedMethodInFinalClassRule.php
+++ b/src/Rules/ProtectedMethodInFinalClassRule.php
@@ -4,27 +4,12 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Rules;
 
-use Nette\Utils\Arrays;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
-use PHPStan\Node\ClassMethod;
-use PHPStan\Node\CollectedDataNode;
 use PHPStan\Node\InClassMethodNode;
 use PHPStan\Rules\Rule;
-use PHPStan\Rules\RuleError;
 use PHPStan\Rules\RuleErrorBuilder;
 use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
-use TomasVotruba\UnusedPublic\CollectorMapper\MethodCallCollectorMapper;
-use TomasVotruba\UnusedPublic\Collectors\AttributeCallableCollector;
-use TomasVotruba\UnusedPublic\Collectors\CallUserFuncCollector;
-use TomasVotruba\UnusedPublic\Collectors\FormTypeClassCollector;
-use TomasVotruba\UnusedPublic\Collectors\MethodCallCollector;
-use TomasVotruba\UnusedPublic\Collectors\PublicClassMethodCollector;
-use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
-use TomasVotruba\UnusedPublic\Configuration;
-use TomasVotruba\UnusedPublic\Enum\RuleTips;
-use TomasVotruba\UnusedPublic\Templates\TemplateMethodCallsProvider;
-use TomasVotruba\UnusedPublic\Templates\UsedMethodAnalyzer;
 
 /**
  * @see \TomasVotruba\UnusedPublic\Tests\Rules\ProtectedClassMethodInFinalClassRule\ProtectedClassMethodInFinalClassRuleTest
@@ -37,8 +22,9 @@ final class ProtectedMethodInFinalClassRule implements Rule
     public const ERROR_MESSAGE = 'Protected method "%s" should be reduced to private visiblity';
 
     public function __construct(
-        private readonly ApiDocStmtAnalyzer       $apiDocStmtAnalyzer,
-    ) {}
+        private readonly ApiDocStmtAnalyzer $apiDocStmtAnalyzer,
+    ) {
+    }
 
     public function getNodeType(): string
     {
@@ -53,7 +39,7 @@ final class ProtectedMethodInFinalClassRule implements Rule
         $methodReflection = $node->getMethodReflection();
         $method = $node->getOriginalNode();
 
-        if (!$method->isProtected()) {
+        if (! $method->isProtected()) {
             return [];
         }
 
@@ -62,8 +48,8 @@ final class ProtectedMethodInFinalClassRule implements Rule
             return [];
         }
 
-        if (!$classReflection->isFinal()) {
-            return[];
+        if (! $classReflection->isFinal()) {
+            return [];
         }
 
         $docComment = $methodReflection->getDocComment();
@@ -72,12 +58,12 @@ final class ProtectedMethodInFinalClassRule implements Rule
         }
 
         $methodName = $methodReflection->getName();
-        if (!$classReflection->hasMethod($methodName)) {
+        if (! $classReflection->hasMethod($methodName)) {
             return [];
         }
 
         $parentClass = $classReflection->getParentClass();
-        while($parentClass !== null) {
+        while ($parentClass !== null) {
             // method is overridding a parent method, which might be called from the base-class
             if ($parentClass->hasMethod($methodName)) {
                 return [];
@@ -86,9 +72,6 @@ final class ProtectedMethodInFinalClassRule implements Rule
             $parentClass = $parentClass->getParentClass();
         }
 
-        return [RuleErrorBuilder::message(
-            sprintf(self::ERROR_MESSAGE, $methodName)
-        )->build()];
+        return [RuleErrorBuilder::message(sprintf(self::ERROR_MESSAGE, $methodName))->build()];
     }
-
 }

--- a/src/Rules/ProtectedMethodInFinalClassRule.php
+++ b/src/Rules/ProtectedMethodInFinalClassRule.php
@@ -36,7 +36,6 @@ final class ProtectedMethodInFinalClassRule implements Rule
      */
     public function processNode(Node $node, Scope $scope): array
     {
-        $methodReflection = $node->getMethodReflection();
         $method = $node->getOriginalNode();
 
         if (! $method->isProtected()) {
@@ -52,6 +51,7 @@ final class ProtectedMethodInFinalClassRule implements Rule
             return [];
         }
 
+        $methodReflection = $node->getMethodReflection();
         $docComment = $methodReflection->getDocComment();
         if ($docComment !== null && $this->apiDocStmtAnalyzer->isApiDocComment($docComment)) {
             return [];

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/ProtectedMethodInFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/ProtectedMethodInFinalClass.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\ProtectedClassMethodInFinalClassRule\Fixture;
+
+final class ProtectedMethodInFinalClass
+{
+    public function publicMethod()
+    {
+    }
+
+    protected function protectedMethod()
+    {
+    }
+
+    private function privateMethod()
+    {
+    }
+
+    static public function staticPublicMethod()
+    {
+    }
+
+    static protected function staticProtectedMethod()
+    {
+    }
+
+    static private function staticPrivateMethod()
+    {
+    }
+}

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/ProtectedMethodInFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/ProtectedMethodInFinalClass.php
@@ -14,15 +14,15 @@ final class ProtectedMethodInFinalClass
     {
     }
 
-    private function protectedMethod()
+    protected function protectedMethod()
+    {
+    }
+
+    protected static function staticProtectedMethod()
     {
     }
 
     private function privateMethod()
-    {
-    }
-
-    private static function staticProtectedMethod()
     {
     }
 

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/ProtectedMethodInFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/ProtectedMethodInFinalClass.php
@@ -10,7 +10,11 @@ final class ProtectedMethodInFinalClass
     {
     }
 
-    protected function protectedMethod()
+    public static function staticPublicMethod()
+    {
+    }
+
+    private function protectedMethod()
     {
     }
 
@@ -18,15 +22,11 @@ final class ProtectedMethodInFinalClass
     {
     }
 
-    static public function staticPublicMethod()
+    private static function staticProtectedMethod()
     {
     }
 
-    static protected function staticProtectedMethod()
-    {
-    }
-
-    static private function staticPrivateMethod()
+    private static function staticPrivateMethod()
     {
     }
 }

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipNonFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipNonFinalClass.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\ProtectedClassMethodInFinalClassRule\Fixture;
+
+class SkipNonFinalClass
+{
+    public function publicMethod()
+    {
+    }
+
+    protected function protectedMethod()
+    {
+    }
+
+    private function privateMethod()
+    {
+    }
+
+    static public function staticPublicMethod()
+    {
+    }
+
+    static protected function staticProtectedMethod()
+    {
+    }
+
+    static private function staticPrivateMethod()
+    {
+    }
+}

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipNonFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipNonFinalClass.php
@@ -10,7 +10,15 @@ class SkipNonFinalClass
     {
     }
 
+    public static function staticPublicMethod()
+    {
+    }
+
     protected function protectedMethod()
+    {
+    }
+
+    protected static function staticProtectedMethod()
     {
     }
 
@@ -18,15 +26,7 @@ class SkipNonFinalClass
     {
     }
 
-    static public function staticPublicMethod()
-    {
-    }
-
-    static protected function staticProtectedMethod()
-    {
-    }
-
-    static private function staticPrivateMethod()
+    private static function staticPrivateMethod()
     {
     }
 }

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipOverriddenProtectedMethodInFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipOverriddenProtectedMethodInFinalClass.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\ProtectedClassMethodInFinalClassRule\Fixture;
+
+final class SkipOverriddenProtectedMethodInFinalClass extends MiddleClass
+{
+    public function publicMethod()
+    {
+    }
+
+    protected function protectedMethod()
+    {
+    }
+
+    private function privateMethod()
+    {
+    }
+
+    static public function staticPublicMethod()
+    {
+    }
+
+    static protected function staticProtectedMethod()
+    {
+    }
+
+    static private function staticPrivateMethod()
+    {
+    }
+}
+
+class MiddleClass extends BaseClass {
+
+    static protected function staticProtectedMethod()
+    {
+    }
+}
+
+
+class BaseClass {
+    protected function protectedMethod()
+    {
+    }
+}

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipOverriddenProtectedMethodInFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipOverriddenProtectedMethodInFinalClass.php
@@ -10,7 +10,15 @@ final class SkipOverriddenProtectedMethodInFinalClass extends MiddleClass
     {
     }
 
+    public static function staticPublicMethod()
+    {
+    }
+
     protected function protectedMethod()
+    {
+    }
+
+    protected static function staticProtectedMethod()
     {
     }
 
@@ -18,28 +26,21 @@ final class SkipOverriddenProtectedMethodInFinalClass extends MiddleClass
     {
     }
 
-    static public function staticPublicMethod()
-    {
-    }
-
-    static protected function staticProtectedMethod()
-    {
-    }
-
-    static private function staticPrivateMethod()
+    private static function staticPrivateMethod()
     {
     }
 }
 
-class MiddleClass extends BaseClass {
-
-    static protected function staticProtectedMethod()
+class MiddleClass extends BaseClass
+{
+    protected static function staticProtectedMethod()
     {
     }
 }
 
 
-class BaseClass {
+class BaseClass
+{
     protected function protectedMethod()
     {
     }

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipProtectedApiMethodInFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipProtectedApiMethodInFinalClass.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\ProtectedClassMethodInFinalClassRule\Fixture;
+
+final class SkipProtectedApiMethodInFinalClass
+{
+    public function publicMethod()
+    {
+    }
+
+    /**
+     * @api
+     */
+    protected function protectedMethod()
+    {
+    }
+
+    private function privateMethod()
+    {
+    }
+
+    static public function staticPublicMethod()
+    {
+    }
+
+    /**
+     * @api
+     */
+    static protected function staticProtectedMethod()
+    {
+    }
+
+    static private function staticPrivateMethod()
+    {
+    }
+}

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipProtectedApiMethodInFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipProtectedApiMethodInFinalClass.php
@@ -17,7 +17,7 @@ final class SkipProtectedApiMethodInFinalClass
     /**
      * @api
      */
-    private function protectedMethod()
+    protected function protectedMethod()
     {
     }
 
@@ -28,7 +28,7 @@ final class SkipProtectedApiMethodInFinalClass
     /**
      * @api
      */
-    private static function staticProtectedMethod()
+    protected static function staticProtectedMethod()
     {
     }
 

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipProtectedApiMethodInFinalClass.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/Fixture/SkipProtectedApiMethodInFinalClass.php
@@ -10,10 +10,14 @@ final class SkipProtectedApiMethodInFinalClass
     {
     }
 
+    public static function staticPublicMethod()
+    {
+    }
+
     /**
      * @api
      */
-    protected function protectedMethod()
+    private function protectedMethod()
     {
     }
 
@@ -21,18 +25,14 @@ final class SkipProtectedApiMethodInFinalClass
     {
     }
 
-    static public function staticPublicMethod()
-    {
-    }
-
     /**
      * @api
      */
-    static protected function staticProtectedMethod()
+    private static function staticProtectedMethod()
     {
     }
 
-    static private function staticPrivateMethod()
+    private static function staticPrivateMethod()
     {
     }
 }

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/ProtectedMethodInFinalClassRuleTest.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/ProtectedMethodInFinalClassRuleTest.php
@@ -31,8 +31,8 @@ final class ProtectedMethodInFinalClassRuleTest extends RuleTestCase
         yield [
             [__DIR__ . '/Fixture/ProtectedMethodInFinalClass.php'],
             [
-                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'protectedMethod'), 13],
-                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'staticProtectedMethod'), 25],
+                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'protectedMethod'), 17],
+                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'staticProtectedMethod'), 21],
             ],
         ];
     }

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/ProtectedMethodInFinalClassRuleTest.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/ProtectedMethodInFinalClassRuleTest.php
@@ -5,21 +5,10 @@ declare(strict_types=1);
 namespace TomasVotruba\UnusedPublic\Tests\Rules\ProtectedClassMethodInFinalClassRule;
 
 use Iterator;
-use PHPStan\Collectors\Collector;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
-use TomasVotruba\UnusedPublic\Collectors\AttributeCallableCollector;
-use TomasVotruba\UnusedPublic\Collectors\CallUserFuncCollector;
-use TomasVotruba\UnusedPublic\Collectors\MethodCallCollector;
-use TomasVotruba\UnusedPublic\Collectors\PublicClassMethodCollector;
-use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
-use TomasVotruba\UnusedPublic\Enum\RuleTips;
-use TomasVotruba\UnusedPublic\Rules\LocalOnlyPublicClassMethodRule;
 use TomasVotruba\UnusedPublic\Rules\ProtectedMethodInFinalClassRule;
-use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\CaseInsensitiveMethodName;
-use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\LocallyUsedEnumMethod;
-use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\LocallyUsedPublicMethod;
 
 final class ProtectedMethodInFinalClassRuleTest extends RuleTestCase
 {
@@ -42,13 +31,11 @@ final class ProtectedMethodInFinalClassRuleTest extends RuleTestCase
         yield [
             [__DIR__ . '/Fixture/ProtectedMethodInFinalClass.php'],
             [
-                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'protectedMethod' ), 13],
-                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'staticProtectedMethod' ), 25]
-            ]
+                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'protectedMethod'), 13],
+                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'staticProtectedMethod'), 25],
+            ],
         ];
-
     }
-
 
     /**
      * @return string[]

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/ProtectedMethodInFinalClassRuleTest.php
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/ProtectedMethodInFinalClassRuleTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\ProtectedClassMethodInFinalClassRule;
+
+use Iterator;
+use PHPStan\Collectors\Collector;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use TomasVotruba\UnusedPublic\Collectors\AttributeCallableCollector;
+use TomasVotruba\UnusedPublic\Collectors\CallUserFuncCollector;
+use TomasVotruba\UnusedPublic\Collectors\MethodCallCollector;
+use TomasVotruba\UnusedPublic\Collectors\PublicClassMethodCollector;
+use TomasVotruba\UnusedPublic\Collectors\StaticMethodCallCollector;
+use TomasVotruba\UnusedPublic\Enum\RuleTips;
+use TomasVotruba\UnusedPublic\Rules\LocalOnlyPublicClassMethodRule;
+use TomasVotruba\UnusedPublic\Rules\ProtectedMethodInFinalClassRule;
+use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\CaseInsensitiveMethodName;
+use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\LocallyUsedEnumMethod;
+use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\LocallyUsedPublicMethod;
+
+final class ProtectedMethodInFinalClassRuleTest extends RuleTestCase
+{
+    /**
+     * @param string[] $filePaths
+     * @param mixed[] $expectedErrorMessagesWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(array $filePaths, array $expectedErrorMessagesWithLines): void
+    {
+        $this->analyse($filePaths, $expectedErrorMessagesWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        yield [[__DIR__ . '/Fixture/SkipOverriddenProtectedMethodInFinalClass.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipNonFinalClass.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipProtectedApiMethodInFinalClass.php'], []];
+
+        yield [
+            [__DIR__ . '/Fixture/ProtectedMethodInFinalClass.php'],
+            [
+                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'protectedMethod' ), 13],
+                [sprintf(ProtectedMethodInFinalClassRule::ERROR_MESSAGE, 'staticProtectedMethod' ), 25]
+            ]
+        ];
+
+    }
+
+
+    /**
+     * @return string[]
+     */
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/configured_rule.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ProtectedMethodInFinalClassRule::class);
+    }
+}

--- a/tests/Rules/ProtectedClassMethodInFinalClassRule/config/configured_rule.neon
+++ b/tests/Rules/ProtectedClassMethodInFinalClassRule/config/configured_rule.neon
@@ -1,0 +1,2 @@
+includes:
+    - ../../../../config/extension.neon


### PR DESCRIPTION
protected methods in final classes are not very useful. private methods can be analyzed easier and phpstan covers more cases for them.

with this PR, we report a error for these unnecessary protected methods, because when these are reduced to private visibility e.g. phpstan private symbol analytics kicks in and might detect unused private methods.

the same is true for protected properties, and I plan to contribute another rule, in case we agree on this one.