### PR TITLE
test: skip deserialize array to object

### DIFF
--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipDeserializeArrayToObject.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipDeserializeArrayToObject.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+final class SkipDeserializeArrayToObject
+{
+    private function __construct(
+        private readonly array $data,
+    ) {
+    }
+
+    public static function deserialize(array $data): self
+    {
+        return new self($data);
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/Source/DeserializeArrayToObjectCaller.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Source/DeserializeArrayToObjectCaller.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\SkipDeserializeArrayToObject;
+
+final class DeserializeArrayToObjectCaller
+{
+    private function go()
+    {
+        array_map(SkipDeserializeArrayToObject::deserialize(...), []);
+    }
+
+    private function goAgain()
+    {
+        array_map([SkipDeserializeArrayToObject::class, 'deserialize'], []);
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -81,6 +81,11 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Source/CallbackMethodCaller.php', __DIR__ . '/Fixture/SkipPublicCallbackMethod.php'], []];
 
         yield [[
+            __DIR__ . '/Source/DeserializeArrayToObjectCaller.php', __DIR__ . '/Fixture/SkipDeserializeArrayToObject.php'],
+            [],
+        ];
+
+        yield [[
             __DIR__ . '/Fixture/SkipNullableUsedPublicMethod.php', __DIR__ . '/Source/NullableClassMethodCaller.php', ],
             [],
         ];


### PR DESCRIPTION
Hello,
it is similar than old issue  https://github.com/TomasVotruba/unused-public/issues/27  but I add another failed test cases.


**Example:**
```php
//collection object
final class ObjectCollection implements Collection
{
    public static function jsonDeserialize(array $data): self
    {
        // Does not detect
        return new self(...array_map(Object::jsonDeserialize(...), $data));
    }

    private function __construct(Object...$items)
    {
        $this->items = array_values($items);
    }
}

//object
final class Object
{
    public static function jsonDeserialize(array $data): self
    {
        ....
    }
    ...
}

//execute
$items = ObjectCollection::jsonDeserialize([]);
```

**Result:**
```
Line   Object.php
 ------ -------------------------------------------------------------------------------------------
  xx     Public method "Object::jsonDeserialize()" is never used
         💡 Either reduce visibility or annotate it or its class with @api

```

It does not detect usage of `Object` in `ObjectCollection`.
Object is used in `new self(...array_map(Object::jsonDeserialize(...), $data))`. 
Same result also with `new self(...array_map([Object::class, 'jsonDeserialize'], $data));`.