### PR TITLE
Remove nette/utils to allow easier install

### DIFF
--- a/build/composer-php-72.json
+++ b/build/composer-php-72.json
@@ -5,10 +5,9 @@
     "license": "MIT",
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
-        "php": "^7.2 || 8.0.*",
+        "php": "^7.2 || ^8.0",
         "phpstan/phpstan": "^1.10.19",
-        "nette/utils": "^3.2",
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^1.12"
     },
     "autoload": {
         "psr-4": {

--- a/rector.php
+++ b/rector.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-use Rector\CodingStyle\Rector\ClassConst\VarConstantCommentRector;
 use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
+use Rector\PHPUnit\Set\PHPUnitSetList;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
 
@@ -14,9 +15,10 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->importNames();
+    $rectorConfig->removeUnusedImports();
 
     $rectorConfig->sets([
-        \Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_100,
+        PHPUnitSetList::PHPUNIT_100,
         LevelSetList::UP_TO_PHP_81,
         SetList::TYPE_DECLARATION,
         SetList::PRIVATIZATION,
@@ -26,7 +28,7 @@ return static function (RectorConfig $rectorConfig): void {
         SetList::CODING_STYLE,
     ]);
 
-    $rectorConfig->ruleWithConfiguration(\Rector\Php55\Rector\String_\StringClassNameToClassConstantRector::class, [
+    $rectorConfig->ruleWithConfiguration(StringClassNameToClassConstantRector::class, [
         'Twig\Extension\ExtensionInterface',
         'PHPUnit\Framework\TestCase',
         'Symfony\Bundle\FrameworkBundle\Controller\Controller',
@@ -36,9 +38,5 @@ return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->skip([
         '*/Fixture/*',
         '*/Source/*',
-
-        VarConstantCommentRector::class => [
-            __DIR__ . '/src/PublicClassMethodMatcher.php',
-        ],
     ]);
 };

--- a/src/Rules/UnusedPublicClassConstRule.php
+++ b/src/Rules/UnusedPublicClassConstRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Rules;
 
-use Nette\Utils\Arrays;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
@@ -17,6 +16,7 @@ use TomasVotruba\UnusedPublic\Configuration;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Enum\Template\BladeRegex;
 use TomasVotruba\UnusedPublic\Templates\TemplateRegexFinder;
+use TomasVotruba\UnusedPublic\Utils\Arrays;
 
 /**
  * @see \TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\UnusedPublicClassConstRuleTest

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Rules;
 
-use Nette\Utils\Arrays;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
@@ -24,6 +23,7 @@ use TomasVotruba\UnusedPublic\Configuration;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Templates\TemplateMethodCallsProvider;
 use TomasVotruba\UnusedPublic\Templates\UsedMethodAnalyzer;
+use TomasVotruba\UnusedPublic\Utils\Arrays;
 
 /**
  * @see \TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\UnusedPublicClassMethodRuleTest

--- a/src/Rules/UnusedPublicPropertyRule.php
+++ b/src/Rules/UnusedPublicPropertyRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Rules;
 
-use Nette\Utils\Arrays;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
@@ -16,6 +15,7 @@ use TomasVotruba\UnusedPublic\Collectors\PublicPropertyFetchCollector;
 use TomasVotruba\UnusedPublic\Collectors\PublicStaticPropertyFetchCollector;
 use TomasVotruba\UnusedPublic\Configuration;
 use TomasVotruba\UnusedPublic\Enum\RuleTips;
+use TomasVotruba\UnusedPublic\Utils\Arrays;
 
 /**
  * @see \TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\UnusedPublicPropertyRuleTest

--- a/src/Templates/TemplateRegexFinder.php
+++ b/src/Templates/TemplateRegexFinder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace TomasVotruba\UnusedPublic\Templates;
 
 use TomasVotruba\UnusedPublic\Finder\TemplateFilesFinder;
+use TomasVotruba\UnusedPublic\Utils\Strings;
 
 final class TemplateRegexFinder
 {
@@ -37,13 +38,12 @@ final class TemplateRegexFinder
         $methodCallNames = [];
         foreach ($templateFilesContents as $templateFileContent) {
             foreach ($innerRegexes as $innerRegex) {
-                preg_match_all($innerRegex, $templateFileContent, $matches);
+                $matches = Strings::matchAll($templateFileContent, $innerRegex);
 
                 foreach ($matches as $match) {
                     $templateMarkupContents = $match['contents'];
 
-                    preg_match_all($targetRegex, $templateMarkupContents, $methodNamesMatches);
-
+                    $methodNamesMatches = Strings::matchAll($templateMarkupContents, $targetRegex);
                     foreach ($methodNamesMatches as $methodNameMatch) {
                         $methodCallNames[] = $methodNameMatch['desired_name'];
                     }

--- a/src/Templates/TemplateRegexFinder.php
+++ b/src/Templates/TemplateRegexFinder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Templates;
 
-use Nette\Utils\Strings;
 use TomasVotruba\UnusedPublic\Finder\TemplateFilesFinder;
 
 final class TemplateRegexFinder
@@ -38,12 +37,13 @@ final class TemplateRegexFinder
         $methodCallNames = [];
         foreach ($templateFilesContents as $templateFileContent) {
             foreach ($innerRegexes as $innerRegex) {
-                $matches = Strings::matchAll($templateFileContent, $innerRegex);
+                preg_match_all($innerRegex, $templateFileContent, $matches);
 
                 foreach ($matches as $match) {
                     $templateMarkupContents = $match['contents'];
 
-                    $methodNamesMatches = Strings::matchAll($templateMarkupContents, $targetRegex);
+                    preg_match_all($targetRegex, $templateMarkupContents, $methodNamesMatches);
+
                     foreach ($methodNamesMatches as $methodNameMatch) {
                         $methodCallNames[] = $methodNameMatch['desired_name'];
                     }

--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Utils;
+
+final class Arrays
+{
+    /**
+     * @param mixed[] $array
+     * @return mixed[]
+     *
+     * @license nette/utils, where exactly copied from
+     */
+    public static function flatten(array $array): array
+    {
+        $result = [];
+
+        $callback = static function ($value) use (&$result): void {
+            $result[] = $value;
+        };
+        array_walk_recursive($array, $callback);
+
+        return $result;
+    }
+}

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Utils;
+
+final class Strings
+{
+    /**
+     * @return mixed[]
+     */
+    public static function matchAll(string $content, string $regex): array
+    {
+        preg_match_all($regex, $content, $matches, PREG_SET_ORDER);
+        return $matches;
+    }
+}

--- a/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
+++ b/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
@@ -17,6 +17,7 @@ use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\Loc
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\LocallyUsedPublicConstantByName;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\UnusedPublicConstant;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\UnusedPublicConstantFromInterface;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\UsedInTestCaseOnly;
 
 final class UnusedPublicClassConstRuleTest extends RuleTestCase
 {
@@ -75,7 +76,7 @@ final class UnusedPublicClassConstRuleTest extends RuleTestCase
 
         yield [[__DIR__ . '/Fixture/SkipInterfaceConstantUsed.php', __DIR__ . '/Source/InterfaceConstantUser.php'], []];
 
-        $errorMessage = sprintf(UnusedPublicClassConstRule::ERROR_MESSAGE, Fixture\UsedInTestCaseOnly::class, 'USE_ME');
+        $errorMessage = sprintf(UnusedPublicClassConstRule::ERROR_MESSAGE, UsedInTestCaseOnly::class, 'USE_ME');
         yield [[
             __DIR__ . '/Fixture/UsedInTestCaseOnly.php',
             __DIR__ . '/Source/TestCaseUser.php',


### PR DESCRIPTION
- make use of preg_match_all()
- use Arrays::flatten() locally
