### PR TITLE
Remove nette/utils to allow easier install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "php": "^8.1",
         "phpstan/phpstan": "^1.10.26",
-        "nette/utils": "^3.2",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/src/CollectorMapper/MethodCallCollectorMapper.php
+++ b/src/CollectorMapper/MethodCallCollectorMapper.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\CollectorMapper;
 
-use Nette\Utils\Arrays;
 use TomasVotruba\UnusedPublic\Enum\ReferenceMarker;
+use TomasVotruba\UnusedPublic\Utils\Arrays;
 use TomasVotruba\UnusedPublic\ValueObject\LocalAndExternalMethodCallReferences;
 
 final class MethodCallCollectorMapper


### PR DESCRIPTION
In https://github.com/TomasVotruba/unused-public/pull/86 one call to `Nette\Util\Arrays::flatten()` was not removed. This PR removes the reference and also removes the dependency to `nette/utils` on the whole.