### PR TITLE
Increased portability

### DIFF
--- a/src/Finder/TemplateFilesFinder.php
+++ b/src/Finder/TemplateFilesFinder.php
@@ -16,7 +16,9 @@ final class TemplateFilesFinder
 
         foreach ($directories as $directory) {
             /** @var string[] $currentTemplateFilePaths */
-            $currentTemplateFilePaths = glob($directory . '/{**/*,*}/*.' . $suffix, GLOB_BRACE);
+            $currentTemplateFilePaths = glob($directory . '/*/*.' . $suffix);
+            $currentTemplateFilePaths = array_merge(glob($directory . '/**/*/*.' . $suffix), $currentTemplateFilePaths);
+            $currentTemplateFilePaths = array_unique($currentTemplateFilePaths);
 
             $templateFilePaths = array_merge($templateFilePaths, $currentTemplateFilePaths);
         }

--- a/src/Finder/TemplateFilesFinder.php
+++ b/src/Finder/TemplateFilesFinder.php
@@ -16,9 +16,13 @@ final class TemplateFilesFinder
 
         foreach ($directories as $directory) {
             /** @var string[] $currentTemplateFilePaths */
-            $currentTemplateFilePaths = glob($directory . '/*/*.' . $suffix);
-            $currentTemplateFilePaths = array_merge(glob($directory . '/**/*/*.' . $suffix), $currentTemplateFilePaths);
-            $currentTemplateFilePaths = array_unique($currentTemplateFilePaths);
+            $currentTemplateFilePathsL1 = glob($directory . '/*/*.' . $suffix);
+            $currentTemplateFilePathsL2 = glob($directory . '/**/*/*.' . $suffix);
+
+            $currentTemplateFilePaths = array_merge(
+                $currentTemplateFilePathsL1 === false ? [] : $currentTemplateFilePathsL1,
+                $currentTemplateFilePathsL2 === false ? [] : $currentTemplateFilePathsL2
+            );
 
             $templateFilePaths = array_merge($templateFilePaths, $currentTemplateFilePaths);
         }


### PR DESCRIPTION
The GLOB_BRACE constant is not available on every system. Instead, I implemented a basic brace expansion in PHP to achieve the same result.

Reference: https://www.php.net/manual/en/function.glob.php

I look forward to your feedback and hope this gets merged soon.