### PR TITLE
Fix type error in CallUserFuncCollector

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,4 +26,3 @@ parameters:
     ignoreErrors:
         # collectors generics
         - '#Parameter (.*?) of method (.*?)Collector::processNode\(\) should be compatible with parameter#'
-        - '#Method (.*?)Collector::processNode\(\) should return.*but returns array#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,4 +26,4 @@ parameters:
     ignoreErrors:
         # collectors generics
         - '#Parameter (.*?) of method (.*?)Collector::processNode\(\) should be compatible with parameter#'
-        - '#Method (.*?)Collector::processNode\(\) should return#'
+        - '#Method (.*?)Collector::processNode\(\) should return.*but returns array#'

--- a/src/Collectors/Callable_/CallUserFuncCollector.php
+++ b/src/Collectors/Callable_/CallUserFuncCollector.php
@@ -46,7 +46,7 @@ final class CallUserFuncCollector implements Collector
 
         $args = $node->getArgs();
         if (count($args) < 1) {
-            return true;
+            return null;
         }
 
         // skip calls in tests, as they are not used in production

--- a/src/Collectors/PublicClassMethodCollector.php
+++ b/src/Collectors/PublicClassMethodCollector.php
@@ -51,7 +51,7 @@ final class PublicClassMethodCollector implements Collector
 
     /**
      * @param ClassMethod $node
-     * @return array<array{class-string, string, int}>|null
+     * @return array{class-string, string, int}|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {


### PR DESCRIPTION
fixes a fatal error because `true` is not allowed to be returned by the native return type