### PR TITLE
Cleanup PHPStan ignore rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.1",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^1.10.49",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -25,5 +25,4 @@ parameters:
 
     ignoreErrors:
         # collectors generics
-        - '#Parameter (.*?) of method (.*?)Collector::processNode\(\) should be compatible with parameter#'
         - '#Method (.*?)Collector::processNode\(\) should return#'


### PR DESCRIPTION
the headliner feature for https://github.com/phpstan/phpstan/releases/tag/1.10.49 makes PHPStan smarter about our Collector generics, which means we no longer have to ignore errors as these no longer happen