### PR TITLE
Fix false detection when static and non-static properties are used together

### DIFF
--- a/src/Rules/UnusedPublicPropertyRule.php
+++ b/src/Rules/UnusedPublicPropertyRule.php
@@ -53,8 +53,10 @@ final class UnusedPublicPropertyRule implements Rule
         $publicPropertyFetchCollector = $node->get(PublicPropertyFetchCollector::class);
         $publicStaticPropertyFetchCollector = $node->get(PublicStaticPropertyFetchCollector::class);
 
-        $publicPropertyFetchCollector = [...$publicPropertyFetchCollector, ...$publicStaticPropertyFetchCollector];
-        $usedProperties = Arrays::flatten($publicPropertyFetchCollector);
+        $usedProperties = [
+            ...Arrays::flatten($publicPropertyFetchCollector),
+            ...Arrays::flatten($publicStaticPropertyFetchCollector),
+        ];
 
         $ruleErrors = [];
 

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-static-and-nonstatic.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-static-and-nonstatic.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicPropertyClass;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicStaticPropertyClass;
+
+$o = new PublicPropertyClass();
+$o->property = 'a value';
+
+PublicStaticPropertyClass::$staticProperty = 'a value';

--- a/tests/Rules/UnusedPublicPropertyRule/Source/PublicStaticPropertyClass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/PublicStaticPropertyClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class PublicStaticPropertyClass
+{
+    public $staticProperty = 'public static';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -104,6 +104,15 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
         ];
 
         yield [[__DIR__ . '/Fixture/plain.php', __DIR__ . '/Source/PublicPropertyClass.php'], []];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/plain-static-and-nonstatic.php',
+                __DIR__ . '/Source/PublicPropertyClass.php',
+                __DIR__ . '/Source/PublicStaticPropertyClass.php',
+            ],
+            [],
+        ];
     }
 
     /**


### PR DESCRIPTION
This pull request fixes the following bug:
When static and non-static properties are used together, the non-static property is falsely detected as unused.