### PR TITLE
Fix false detection when using superclass properties or constants

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -28,6 +28,8 @@ services:
     - TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer
     - TomasVotruba\UnusedPublic\ClassMethodCallReferenceResolver
     - TomasVotruba\UnusedPublic\CollectorMapper\MethodCallCollectorMapper
+    - TomasVotruba\UnusedPublic\ConstantReference\ParentConstantReferenceResolver
+    - TomasVotruba\UnusedPublic\PropertyReference\ParentPropertyReferenceResolver
     # templates
     - TomasVotruba\UnusedPublic\Templates\TemplateMethodCallsProvider
     - TomasVotruba\UnusedPublic\Templates\TemplateRegexFinder

--- a/src/Collectors/PublicPropertyFetchCollector.php
+++ b/src/Collectors/PublicPropertyFetchCollector.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\TypeWithClassName;
 use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\PropertyReference\ParentPropertyReferenceResolver;
 
 /**
  * @implements Collector<PropertyFetch, string[]>
@@ -21,6 +22,7 @@ use TomasVotruba\UnusedPublic\Configuration;
 final class PublicPropertyFetchCollector implements Collector
 {
     public function __construct(
+        private readonly ParentPropertyReferenceResolver $parentPropertyReferenceResolver,
         private readonly Configuration $configuration,
         private readonly ClassTypeDetector $classTypeDetector,
     ) {
@@ -66,6 +68,10 @@ final class PublicPropertyFetchCollector implements Collector
         $className = $propertyFetcherType->getClassName();
         $propertyName = $node->name->toString();
 
-        return [$className . '::' . $propertyName];
+        $propertyReferences = [$className . '::' . $propertyName];
+        $parentPropertyReferences = $this->parentPropertyReferenceResolver->findParentPropertyReferences($className, $propertyName);
+        $propertyReferences = [...$propertyReferences, ...$parentPropertyReferences];
+
+        return $propertyReferences;
     }
 }

--- a/src/Collectors/PublicStaticPropertyFetchCollector.php
+++ b/src/Collectors/PublicStaticPropertyFetchCollector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\PropertyReference\ParentPropertyReferenceResolver;
 
 /**
  * @implements Collector<StaticPropertyFetch, string[]>
@@ -18,7 +19,8 @@ use TomasVotruba\UnusedPublic\Configuration;
 final class PublicStaticPropertyFetchCollector implements Collector
 {
     public function __construct(
-        private readonly Configuration $configuration
+        private readonly ParentPropertyReferenceResolver $parentPropertyReferenceResolver,
+        private readonly Configuration $configuration,
     ) {
     }
 
@@ -53,6 +55,10 @@ final class PublicStaticPropertyFetchCollector implements Collector
         $className = $node->class->toString();
         $propertyName = $node->name->toString();
 
-        return [$className . '::' . $propertyName];
+        $propertyReferences = [$className . '::' . $propertyName];
+        $parentPropertyReferences = $this->parentPropertyReferenceResolver->findParentPropertyReferences($className, $propertyName);
+        $propertyReferences = [...$propertyReferences, ...$parentPropertyReferences];
+
+        return $propertyReferences;
     }
 }

--- a/src/ConstantReference/ParentConstantReferenceResolver.php
+++ b/src/ConstantReference/ParentConstantReferenceResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\ConstantReference;
+
+use PHPStan\Reflection\ReflectionProvider;
+
+final class ParentConstantReferenceResolver
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findParentConstantReferences(string $className, string $constantName): array
+    {
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $constantReferences = [];
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasConstant($constantName)) {
+                $constantReferences[] = $parentClassReflection->getName() . '::' . $constantName;
+            }
+        }
+
+        return $constantReferences;
+    }
+}

--- a/src/PropertyReference/ParentPropertyReferenceResolver.php
+++ b/src/PropertyReference/ParentPropertyReferenceResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\PropertyReference;
+
+use PHPStan\Reflection\ReflectionProvider;
+
+final class ParentPropertyReferenceResolver
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findParentPropertyReferences(string $className, string $propertyName): array
+    {
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $propertyReferences = [];
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasNativeProperty($propertyName)) {
+                $propertyReferences[] = $parentClassReflection->getName() . '::' . $propertyName;
+            }
+        }
+
+        return $propertyReferences;
+    }
+}

--- a/tests/Rules/UnusedPublicClassConstRule/Fixture/SkipUsedPublicConstantInSubclass.php
+++ b/tests/Rules/UnusedPublicClassConstRule/Fixture/SkipUsedPublicConstantInSubclass.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
 
-final class SkipUsedConstantInSubclass extends PublicConstant
+final class SkipUsedPublicConstantInSubclass extends PublicConstant
 {
 }

--- a/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
+++ b/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
@@ -69,8 +69,12 @@ final class UnusedPublicClassConstRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipApiPublicConstant.php'], []];
         yield [[__DIR__ . '/Fixture/SkipApiClassPublicConstant.php'], []];
         yield [[__DIR__ . '/Fixture/SkipUsedPublicConstant.php', __DIR__ . '/Source/ConstantUser.php'], []];
-        yield [[
-            __DIR__ . '/Fixture/SkipUsedConstantInSubclass.php', __DIR__ . '/Source/ConstantUserFromSubclass.php', ],
+        yield [
+            [
+                __DIR__ . '/Fixture/PublicConstant.php',
+                __DIR__ . '/Fixture/SkipUsedPublicConstantInSubclass.php',
+                __DIR__ . '/Source/ConstantUserFromSubclass.php',
+            ],
             [],
         ];
 

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-superclass-static.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-superclass-static.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicStaticPropertySubclass;
+
+PublicStaticPropertySubclass::$staticProperty = 'a value';

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-superclass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-superclass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicPropertySubclass;
+
+$o = new PublicPropertySubclass();
+$o->property = 'a value';

--- a/tests/Rules/UnusedPublicPropertyRule/Source/PublicPropertySubclass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/PublicPropertySubclass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class PublicPropertySubclass extends PublicPropertyClass
+{
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Source/PublicStaticPropertySubclass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/PublicStaticPropertySubclass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class PublicStaticPropertySubclass extends PublicStaticPropertyClass
+{
+}

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -113,6 +113,24 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
             ],
             [],
         ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/plain-superclass.php',
+                __DIR__ . '/Source/PublicPropertyClass.php',
+                __DIR__ . '/Source/PublicPropertySubclass.php',
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/plain-superclass-static.php',
+                __DIR__ . '/Source/PublicStaticPropertyClass.php',
+                __DIR__ . '/Source/PublicStaticPropertySubclass.php',
+            ],
+            [],
+        ];
     }
 
     /**


### PR DESCRIPTION
This pull request fixes the following bug:
When using superclass properties or constants, they are falsely detected as unused.