### PR TITLE
Fix type error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "tomasvotruba/cognitive-complexity": "^0.2.2",
         "php-parallel-lint/php-parallel-lint": "^1.3",
         "tomasvotruba/type-coverage": "^0.2",
-        "symplify/easy-ci": "^11.2"
+        "symplify/easy-ci": "^11.2",
+        "nikic/php-parser": "^4.18"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I ran the `composer phpstan` command on the `main` branch and got an error, so I fixed it using the [global type alias](https://phpstan.org/writing-php-code/phpdoc-types#global-type-aliases).