### PR TITLE
Add support for `@internal` annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,22 @@ final class Book
     }
 }
 ```
+
+## Public Methods Used in Tests Only
+
+Some public methods are designed to be used in tests only. Is element reported as unused, but it's actually used in tests?
+
+Mark the class or element with `@internal` annotation to reported as used:
+
+```php
+final class Book
+{
+    /**
+     * @internal
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}
+```

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -26,6 +26,7 @@ services:
     - TomasVotruba\UnusedPublic\MethodTypeDetector
     - TomasVotruba\UnusedPublic\ClassTypeDetector
     - TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer
+    - TomasVotruba\UnusedPublic\InternalDocStmtAnalyzer
     - TomasVotruba\UnusedPublic\ClassMethodCallReferenceResolver
     - TomasVotruba\UnusedPublic\CollectorMapper\MethodCallCollectorMapper
     - TomasVotruba\UnusedPublic\ConstantReference\ParentConstantReferenceResolver

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -28,6 +28,8 @@ services:
     - TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer
     - TomasVotruba\UnusedPublic\ClassMethodCallReferenceResolver
     - TomasVotruba\UnusedPublic\CollectorMapper\MethodCallCollectorMapper
+    - TomasVotruba\UnusedPublic\ConstantReference\ParentConstantReferenceResolver
+    - TomasVotruba\UnusedPublic\PropertyReference\ParentPropertyReferenceResolver
     # templates
     - TomasVotruba\UnusedPublic\Templates\TemplateMethodCallsProvider
     - TomasVotruba\UnusedPublic\Templates\TemplateRegexFinder

--- a/src/CallReferece/CallReferencesFlatter.php
+++ b/src/CallReferece/CallReferencesFlatter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\CallReferece;
 
-use TomasVotruba\UnusedPublic\Enum\ReferenceMarker;
 use TomasVotruba\UnusedPublic\ValueObject\MethodCallReference;
 
 final class CallReferencesFlatter
@@ -18,15 +17,7 @@ final class CallReferencesFlatter
         $classMethodReferences = [];
 
         foreach ($classMethodCallReferences as $classMethodCallReference) {
-            $className = $classMethodCallReference->getClass();
-            $methodName = $classMethodCallReference->getMethod();
-
-            $classMethodReference = $className . '::' . $methodName;
-            if ($classMethodCallReference->isLocal()) {
-                $classMethodReference = ReferenceMarker::LOCAL . $classMethodReference;
-            }
-
-            $classMethodReferences[] = $classMethodReference;
+            $classMethodReferences[] = (string) $classMethodCallReference;
         }
 
         return $classMethodReferences;

--- a/src/ClassMethodCallReferenceResolver.php
+++ b/src/ClassMethodCallReferenceResolver.php
@@ -7,12 +7,18 @@ namespace TomasVotruba\UnusedPublic;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\ThisType;
 use PHPStan\Type\TypeCombinator;
 use TomasVotruba\UnusedPublic\ValueObject\MethodCallReference;
 
 final class ClassMethodCallReferenceResolver
 {
+    public function __construct(
+        private readonly ClassTypeDetector $classTypeDetector,
+    ) {
+    }
+
     /**
      * @return MethodCallReference[]
      */
@@ -37,9 +43,12 @@ final class ClassMethodCallReferenceResolver
             $isLocal = true;
         }
 
+        $classReflection = $scope->getClassReflection();
+        $isTest = $classReflection instanceof ClassReflection && $this->classTypeDetector->isTestClass($classReflection);
+
         $methodCallReferences = [];
         foreach ($callerType->getReferencedClasses() as $className) {
-            $methodCallReferences[] = new MethodCallReference($className, $methodCall->name->toString(), $isLocal);
+            $methodCallReferences[] = new MethodCallReference($className, $methodCall->name->toString(), $isLocal, $isTest);
         }
 
         return $methodCallReferences;

--- a/src/CollectorMapper/MethodCallCollectorMapper.php
+++ b/src/CollectorMapper/MethodCallCollectorMapper.php
@@ -36,9 +36,9 @@ final class MethodCallCollectorMapper
 
         foreach ($methodCallReferences as $methodCallReference) {
             if (str_contains($methodCallReference, ReferenceMarker::LOCAL)) {
-                $localMethodCallReferences[] = str_replace(ReferenceMarker::LOCAL, '', $methodCallReference);
+                $localMethodCallReferences[] = MethodCallReference::fromString(str_replace(ReferenceMarker::LOCAL, '', $methodCallReference));
             } else {
-                $externalMethodCallReferences[] = $methodCallReference;
+                $externalMethodCallReferences[] = MethodCallReference::fromString($methodCallReference);
             }
         }
 

--- a/src/CollectorMapper/MethodCallCollectorMapper.php
+++ b/src/CollectorMapper/MethodCallCollectorMapper.php
@@ -7,24 +7,20 @@ namespace TomasVotruba\UnusedPublic\CollectorMapper;
 use TomasVotruba\UnusedPublic\Enum\ReferenceMarker;
 use TomasVotruba\UnusedPublic\Utils\Arrays;
 use TomasVotruba\UnusedPublic\ValueObject\LocalAndExternalMethodCallReferences;
+use TomasVotruba\UnusedPublic\ValueObject\MethodCallReference;
 
 final class MethodCallCollectorMapper
 {
     /**
      * @param array<array<string, mixed[]>> $nestedReferencesByFiles
-     * @return string[]
+     * @return MethodCallReference[]
      */
     public function mapToMethodCallReferences(array $nestedReferencesByFiles): array
     {
         $methodCallReferences = $this->mergeAndFlatten($nestedReferencesByFiles);
 
-        // remove ReferenceMaker::LOCAL prefix
-        return array_map(static function (string $methodCallReference): string {
-            if (str_starts_with($methodCallReference, ReferenceMarker::LOCAL)) {
-                return substr($methodCallReference, strlen(ReferenceMarker::LOCAL));
-            }
-
-            return $methodCallReference;
+        return array_map(static function (string $methodCallReference): MethodCallReference {
+            return MethodCallReference::fromString($methodCallReference);
         }, $methodCallReferences);
     }
 
@@ -39,8 +35,8 @@ final class MethodCallCollectorMapper
         $externalMethodCallReferences = [];
 
         foreach ($methodCallReferences as $methodCallReference) {
-            if (str_starts_with($methodCallReference, ReferenceMarker::LOCAL)) {
-                $localMethodCallReferences[] = substr($methodCallReference, strlen(ReferenceMarker::LOCAL));
+            if (str_contains($methodCallReference, ReferenceMarker::LOCAL)) {
+                $localMethodCallReferences[] = str_replace(ReferenceMarker::LOCAL, '', $methodCallReference);
             } else {
                 $externalMethodCallReferences[] = $methodCallReference;
             }

--- a/src/Collectors/Callable_/CallUserFuncCollector.php
+++ b/src/Collectors/Callable_/CallUserFuncCollector.php
@@ -9,9 +9,7 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
-use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\Constant\ConstantArrayType;
-use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
@@ -21,7 +19,6 @@ final class CallUserFuncCollector implements Collector
 {
     public function __construct(
         private readonly Configuration $configuration,
-        private readonly ClassTypeDetector $classTypeDetector,
     ) {
     }
 
@@ -46,13 +43,6 @@ final class CallUserFuncCollector implements Collector
 
         $args = $node->getArgs();
         if (count($args) < 1) {
-            return null;
-        }
-
-        // skip calls in tests, as they are not used in production
-        $classReflection = $scope->getClassReflection();
-        if ($classReflection instanceof ClassReflection
-            && $this->classTypeDetector->isTestClass($classReflection)) {
             return null;
         }
 

--- a/src/Collectors/MethodCall/MethodCallCollector.php
+++ b/src/Collectors/MethodCall/MethodCallCollector.php
@@ -9,11 +9,9 @@ use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
-use PHPStan\Reflection\ClassReflection;
 use TomasVotruba\UnusedPublic\CallReferece\CallReferencesFlatter;
 use TomasVotruba\UnusedPublic\CallReferece\ParentCallReferenceResolver;
 use TomasVotruba\UnusedPublic\ClassMethodCallReferenceResolver;
-use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
@@ -25,7 +23,6 @@ final class MethodCallCollector implements Collector
         private readonly ParentCallReferenceResolver $parentCallReferenceResolver,
         private readonly ClassMethodCallReferenceResolver $classMethodCallReferenceResolver,
         private readonly Configuration $configuration,
-        private readonly ClassTypeDetector $classTypeDetector,
         private readonly CallReferencesFlatter $callReferencesFlatter,
     ) {
     }
@@ -47,13 +44,6 @@ final class MethodCallCollector implements Collector
 
         // unable to resolve method name
         if ($node->name instanceof Expr) {
-            return null;
-        }
-
-        // skip calls in tests, as they are not used in production
-        $classReflection = $scope->getClassReflection();
-        if ($classReflection instanceof ClassReflection
-            && $this->classTypeDetector->isTestClass($classReflection)) {
             return null;
         }
 

--- a/src/Collectors/MethodCall/MethodCallableCollector.php
+++ b/src/Collectors/MethodCall/MethodCallableCollector.php
@@ -9,10 +9,8 @@ use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Node\MethodCallableNode;
-use PHPStan\Reflection\ClassReflection;
 use TomasVotruba\UnusedPublic\CallReferece\CallReferencesFlatter;
 use TomasVotruba\UnusedPublic\ClassMethodCallReferenceResolver;
-use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
@@ -23,7 +21,6 @@ final class MethodCallableCollector implements Collector
     public function __construct(
         private readonly ClassMethodCallReferenceResolver $classMethodCallReferenceResolver,
         private readonly Configuration $configuration,
-        private readonly ClassTypeDetector $classTypeDetector,
         private readonly CallReferencesFlatter $callReferencesFlatter,
     ) {
     }
@@ -45,13 +42,6 @@ final class MethodCallableCollector implements Collector
 
         // unable to resolve method name
         if ($node->getName() instanceof Expr) {
-            return null;
-        }
-
-        // skip calls in tests, as they are not used in production
-        $classReflection = $scope->getClassReflection();
-        if ($classReflection instanceof ClassReflection
-            && $this->classTypeDetector->isTestClass($classReflection)) {
             return null;
         }
 

--- a/src/Collectors/PublicClassLikeConstCollector.php
+++ b/src/Collectors/PublicClassLikeConstCollector.php
@@ -11,6 +11,7 @@ use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
 use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\InternalDocStmtAnalyzer;
 
 /**
  * @implements Collector<ClassConst, array<array{class-string, string, int}>>
@@ -19,6 +20,7 @@ final class PublicClassLikeConstCollector implements Collector
 {
     public function __construct(
         private readonly ApiDocStmtAnalyzer $apiDocStmtAnalyzer,
+        private readonly InternalDocStmtAnalyzer $internalDocStmtAnalyzer,
         private readonly Configuration $configuration,
     ) {
     }
@@ -51,9 +53,11 @@ final class PublicClassLikeConstCollector implements Collector
             return null;
         }
 
+        $isInternal = $this->internalDocStmtAnalyzer->isInternalDoc($node, $classReflection);
+
         $constantNames = [];
         foreach ($node->consts as $constConst) {
-            $constantNames[] = [$classReflection->getName(), $constConst->name->toString(), $node->getLine()];
+            $constantNames[] = [$classReflection->getName(), $constConst->name->toString(), $node->getLine(), $isInternal];
         }
 
         return $constantNames;

--- a/src/Collectors/PublicClassMethodCollector.php
+++ b/src/Collectors/PublicClassMethodCollector.php
@@ -11,6 +11,7 @@ use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
 use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\InternalDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\MethodTypeDetector;
 use TomasVotruba\UnusedPublic\PublicClassMethodMatcher;
 
@@ -38,6 +39,7 @@ final class PublicClassMethodCollector implements Collector
 
     public function __construct(
         private readonly ApiDocStmtAnalyzer $apiDocStmtAnalyzer,
+        private readonly InternalDocStmtAnalyzer $internalDocStmtAnalyzer,
         private readonly PublicClassMethodMatcher $publicClassMethodMatcher,
         private readonly MethodTypeDetector $methodTypeDetector,
         private readonly Configuration $configuration,
@@ -93,7 +95,9 @@ final class PublicClassMethodCollector implements Collector
             return null;
         }
 
-        return [$classReflection->getName(), $methodName, $node->getLine()];
+        $isInternal = $this->internalDocStmtAnalyzer->isInternalDoc($node, $classReflection);
+
+        return [$classReflection->getName(), $methodName, $node->getLine(), $isInternal];
     }
 
     private function shouldSkip(ClassReflection $classReflection, ClassMethod $classMethod, Scope $scope): bool

--- a/src/Collectors/PublicPropertyFetchCollector.php
+++ b/src/Collectors/PublicPropertyFetchCollector.php
@@ -15,6 +15,7 @@ use PHPStan\Type\TypeWithClassName;
 use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 use TomasVotruba\UnusedPublic\PropertyReference\ParentPropertyReferenceResolver;
+use TomasVotruba\UnusedPublic\ValueObject\PropertyReference;
 
 /**
  * @implements Collector<PropertyFetch, string[]>
@@ -60,18 +61,16 @@ final class PublicPropertyFetchCollector implements Collector
             return null;
         }
 
-        $classReflection = $scope->getClassReflection();
-        if ($classReflection instanceof ClassReflection && $this->classTypeDetector->isTestClass($classReflection)) {
-            return null;
-        }
-
         $className = $propertyFetcherType->getClassName();
         $propertyName = $node->name->toString();
 
-        $propertyReferences = [$className . '::' . $propertyName];
-        $parentPropertyReferences = $this->parentPropertyReferenceResolver->findParentPropertyReferences($className, $propertyName);
-        $propertyReferences = [...$propertyReferences, ...$parentPropertyReferences];
+        $classReflection = $scope->getClassReflection();
+        $isTest = $classReflection instanceof ClassReflection && $this->classTypeDetector->isTestClass($classReflection);
 
-        return $propertyReferences;
+        $propertyReference = new PropertyReference($className, $propertyName, $isTest);
+        $propertyReferences = [(string) $propertyReference];
+        $parentPropertyReferences = $this->parentPropertyReferenceResolver->findParentPropertyReferences($className, $propertyName);
+
+        return [...$propertyReferences, ...$parentPropertyReferences];
     }
 }

--- a/src/Collectors/PublicPropertyFetchCollector.php
+++ b/src/Collectors/PublicPropertyFetchCollector.php
@@ -14,6 +14,7 @@ use PHPStan\Reflection\ClassReflection;
 use PHPStan\Type\TypeWithClassName;
 use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\PropertyReference\ParentPropertyReferenceResolver;
 
 /**
  * @implements Collector<PropertyFetch, string[]>
@@ -21,6 +22,7 @@ use TomasVotruba\UnusedPublic\Configuration;
 final class PublicPropertyFetchCollector implements Collector
 {
     public function __construct(
+        private readonly ParentPropertyReferenceResolver $parentPropertyReferenceResolver,
         private readonly Configuration $configuration,
         private readonly ClassTypeDetector $classTypeDetector,
     ) {
@@ -66,6 +68,10 @@ final class PublicPropertyFetchCollector implements Collector
         $className = $propertyFetcherType->getClassName();
         $propertyName = $node->name->toString();
 
-        return [$className . '::' . $propertyName];
+        $propertyReferences = [$className . '::' . $propertyName];
+        $parentPropertyReferences = $this->parentPropertyReferenceResolver->findParentPropertyReferences($className, $propertyName);
+        $propertyReferences = [...$propertyReferences, ...$parentPropertyReferences];
+
+        return $propertyReferences;
     }
 }

--- a/src/Collectors/PublicStaticPropertyFetchCollector.php
+++ b/src/Collectors/PublicStaticPropertyFetchCollector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Name;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\PropertyReference\ParentPropertyReferenceResolver;
 
 /**
  * @implements Collector<StaticPropertyFetch, string[]>
@@ -18,7 +19,8 @@ use TomasVotruba\UnusedPublic\Configuration;
 final class PublicStaticPropertyFetchCollector implements Collector
 {
     public function __construct(
-        private readonly Configuration $configuration
+        private readonly ParentPropertyReferenceResolver $parentPropertyReferenceResolver,
+        private readonly Configuration $configuration,
     ) {
     }
 
@@ -53,6 +55,10 @@ final class PublicStaticPropertyFetchCollector implements Collector
         $className = $node->class->toString();
         $propertyName = $node->name->toString();
 
-        return [$className . '::' . $propertyName];
+        $propertyReferences = [$className . '::' . $propertyName];
+        $parentPropertyReferences = $this->parentPropertyReferenceResolver->findParentPropertyReferences($className, $propertyName);
+        $propertyReferences = [...$propertyReferences, ...$parentPropertyReferences];
+
+        return $propertyReferences;
     }
 }

--- a/src/Collectors/StaticCall/StaticMethodCallCollector.php
+++ b/src/Collectors/StaticCall/StaticMethodCallCollector.php
@@ -13,6 +13,7 @@ use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
 use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\ValueObject\MethodCallReference;
 
 /**
  * @implements Collector<StaticCall, array<string>|null>
@@ -48,13 +49,16 @@ final class StaticMethodCallCollector implements Collector
             return null;
         }
 
-        // skip calls in tests, as they are not used in production
         $classReflection = $scope->getClassReflection();
-        if ($classReflection instanceof ClassReflection
-            && $this->classTypeDetector->isTestClass($classReflection)) {
-            return null;
-        }
+        $isTest = $classReflection instanceof ClassReflection && $this->classTypeDetector->isTestClass($classReflection);
 
-        return [$node->class->toString() . '::' . $node->name->toString()];
+        $classMethodCallReference = new MethodCallReference(
+            $node->class->toString(),
+            $node->name->toString(),
+            false,
+            $isTest,
+        );
+
+        return [(string) $classMethodCallReference];
     }
 }

--- a/src/Collectors/StaticCall/StaticMethodCallableCollector.php
+++ b/src/Collectors/StaticCall/StaticMethodCallableCollector.php
@@ -13,6 +13,7 @@ use PHPStan\Node\StaticMethodCallableNode;
 use PHPStan\Reflection\ClassReflection;
 use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\ValueObject\MethodCallReference;
 
 /**
  * @implements Collector<StaticMethodCallableNode, array<string>|null>
@@ -48,13 +49,16 @@ final class StaticMethodCallableCollector implements Collector
             return null;
         }
 
-        // skip calls in tests, as they are not used in production
         $classReflection = $scope->getClassReflection();
-        if ($classReflection instanceof ClassReflection
-            && $this->classTypeDetector->isTestClass($classReflection)) {
-            return null;
-        }
+        $isTest = $classReflection instanceof ClassReflection && $this->classTypeDetector->isTestClass($classReflection);
 
-        return [$node->getClass()->toString() . '::' . $node->getName()->toString()];
+        $classMethodCallReference = new MethodCallReference(
+            $node->getClass()->toString(),
+            $node->getName()->toString(),
+            false,
+            $isTest,
+        );
+
+        return [(string) $classMethodCallReference];
     }
 }

--- a/src/ConstantReference/ParentConstantReferenceResolver.php
+++ b/src/ConstantReference/ParentConstantReferenceResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\ConstantReference;
+
+use PHPStan\Reflection\ReflectionProvider;
+
+final class ParentConstantReferenceResolver
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findParentConstantReferences(string $className, string $constantName): array
+    {
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $constantReferences = [];
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasConstant($constantName)) {
+                $constantReferences[] = $parentClassReflection->getName() . '::' . $constantName;
+            }
+        }
+
+        return $constantReferences;
+    }
+}

--- a/src/Enum/ReferenceMarker.php
+++ b/src/Enum/ReferenceMarker.php
@@ -9,5 +9,10 @@ final class ReferenceMarker
     /**
      * @var string
      */
-    public const LOCAL = 'local::';
+    public const LOCAL = 'local@';
+
+    /**
+     * @var string
+     */
+    public const TEST = 'test@';
 }

--- a/src/Enum/RuleTips.php
+++ b/src/Enum/RuleTips.php
@@ -15,5 +15,5 @@ final class RuleTips
     /**
      * @var string
      */
-    public const NARROW_SCOPE = 'Make it private or protected';
+    public const NARROW_SCOPE = 'Make it private or protected, or annotate it or its class with @internal if it is used in tests';
 }

--- a/src/Enum/RuleTips.php
+++ b/src/Enum/RuleTips.php
@@ -10,7 +10,7 @@ final class RuleTips
      * @todo this wont make sense anymore, as there will be a rule to make method private/protected
      * @var string
      */
-    public const SOLUTION_MESSAGE = 'Either reduce visibility or annotate it or its class with @api';
+    public const SOLUTION_MESSAGE = 'Consider reducing visibility, annotating it or its class with @api, or with @internal if it is used in tests only';
 
     /**
      * @var string

--- a/src/InternalDocStmtAnalyzer.php
+++ b/src/InternalDocStmtAnalyzer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Stmt;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\Reflection\ClassReflection;
+
+final class InternalDocStmtAnalyzer
+{
+    public function isInternalDoc(Stmt $stmt, ClassReflection $classReflection): bool
+    {
+        if ($classReflection->getResolvedPhpDoc() instanceof ResolvedPhpDocBlock) {
+            $resolvedPhpDoc = $classReflection->getResolvedPhpDoc();
+            if (str_contains($resolvedPhpDoc->getPhpDocString(), '@internal')) {
+                return true;
+            }
+        }
+
+        $docComment = $stmt->getDocComment();
+        if (! $docComment instanceof Doc) {
+            return false;
+        }
+
+        return $this->isInternalDocComment($docComment->getText());
+    }
+
+    public function isInternalDocComment(string $docComment): bool
+    {
+        return str_contains($docComment, '@internal');
+    }
+}

--- a/src/PropertyReference/ParentPropertyReferenceResolver.php
+++ b/src/PropertyReference/ParentPropertyReferenceResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\PropertyReference;
+
+use PHPStan\Reflection\ReflectionProvider;
+
+final class ParentPropertyReferenceResolver
+{
+    public function __construct(
+        private readonly ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    /**
+     * @return string[]
+     */
+    public function findParentPropertyReferences(string $className, string $propertyName): array
+    {
+        if (! $this->reflectionProvider->hasClass($className)) {
+            return [];
+        }
+
+        $classReflection = $this->reflectionProvider->getClass($className);
+
+        $propertyReferences = [];
+        foreach ($classReflection->getParents() as $parentClassReflection) {
+            if ($parentClassReflection->hasNativeProperty($propertyName)) {
+                $propertyReferences[] = $parentClassReflection->getName() . '::' . $propertyName;
+            }
+        }
+
+        return $propertyReferences;
+    }
+}

--- a/src/PublicClassMethodMatcher.php
+++ b/src/PublicClassMethodMatcher.php
@@ -22,14 +22,14 @@ final class PublicClassMethodMatcher
     ) {
     }
 
-    public function shouldSkipClassReflection(ClassReflection $classReflection): bool
+    public function shouldSkipClassReflection(ClassReflection $classReflection, bool $isInternal = false): bool
     {
         // skip interface as required, traits as unable to detect for sure
         if ($classReflection->isInterface() || $classReflection->isTrait()) {
             return true;
         }
 
-        if ($this->classTypeDetector->isTestClass($classReflection)) {
+        if (! $isInternal && $this->classTypeDetector->isTestClass($classReflection)) {
             return true;
         }
 

--- a/src/Rules/UnusedPublicPropertyRule.php
+++ b/src/Rules/UnusedPublicPropertyRule.php
@@ -53,8 +53,10 @@ final class UnusedPublicPropertyRule implements Rule
         $publicPropertyFetchCollector = $node->get(PublicPropertyFetchCollector::class);
         $publicStaticPropertyFetchCollector = $node->get(PublicStaticPropertyFetchCollector::class);
 
-        $publicPropertyFetchCollector = [...$publicPropertyFetchCollector, ...$publicStaticPropertyFetchCollector];
-        $usedProperties = Arrays::flatten($publicPropertyFetchCollector);
+        $usedProperties = [
+            ...Arrays::flatten($publicPropertyFetchCollector),
+            ...Arrays::flatten($publicStaticPropertyFetchCollector),
+        ];
 
         $ruleErrors = [];
 

--- a/src/ValueObject/ConstantReference.php
+++ b/src/ValueObject/ConstantReference.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\ValueObject;
+
+use Stringable;
+use TomasVotruba\UnusedPublic\Enum\ReferenceMarker;
+
+final class ConstantReference implements Stringable
+{
+    public static function fromString(string $constantReference): self
+    {
+        $isTest = false;
+        if (str_contains($constantReference, ReferenceMarker::TEST)) {
+            $isTest = true;
+            $constantReference = str_replace(ReferenceMarker::TEST, '', $constantReference);
+        }
+
+        [$class, $constant] = explode('::', $constantReference);
+
+        return new self($class, $constant, $isTest);
+    }
+
+    public function __construct(
+        private readonly string $class,
+        private readonly string $constant,
+        private readonly bool $isTest,
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getConstant(): string
+    {
+        return $this->constant;
+    }
+
+    public function isTest(): bool
+    {
+        return $this->isTest;
+    }
+
+    public function __toString(): string
+    {
+        $className = $this->getClass();
+        $constantName = $this->getConstant();
+
+        $constantReference = $className . '::' . $constantName;
+        if ($this->isTest()) {
+            $constantReference = ReferenceMarker::TEST . $constantReference;
+        }
+
+        return $constantReference;
+    }
+}

--- a/src/ValueObject/LocalAndExternalMethodCallReferences.php
+++ b/src/ValueObject/LocalAndExternalMethodCallReferences.php
@@ -7,8 +7,8 @@ namespace TomasVotruba\UnusedPublic\ValueObject;
 final class LocalAndExternalMethodCallReferences
 {
     /**
-     * @param string[] $localMethodCallReferences
-     * @param string[] $externalMethodCallReferences
+     * @param MethodCallReference[] $localMethodCallReferences
+     * @param MethodCallReference[] $externalMethodCallReferences
      */
     public function __construct(
         private readonly array $localMethodCallReferences,
@@ -17,7 +17,7 @@ final class LocalAndExternalMethodCallReferences
     }
 
     /**
-     * @return string[]
+     * @return MethodCallReference[]
      */
     public function getLocalMethodCallReferences(): array
     {
@@ -25,7 +25,7 @@ final class LocalAndExternalMethodCallReferences
     }
 
     /**
-     * @return string[]
+     * @return MethodCallReference[]
      */
     public function getExternalMethodCallReferences(): array
     {

--- a/src/ValueObject/MethodCallReference.php
+++ b/src/ValueObject/MethodCallReference.php
@@ -4,12 +4,35 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\ValueObject;
 
-final class MethodCallReference
+use Stringable;
+use TomasVotruba\UnusedPublic\Enum\ReferenceMarker;
+
+final class MethodCallReference implements Stringable
 {
+    public static function fromString(string $methodCallReference): self
+    {
+        $isLocal = false;
+        if (str_contains($methodCallReference, ReferenceMarker::LOCAL)) {
+            $isLocal = true;
+            $methodCallReference = str_replace(ReferenceMarker::LOCAL, '', $methodCallReference);
+        }
+
+        $isTest = false;
+        if (str_contains($methodCallReference, ReferenceMarker::TEST)) {
+            $isTest = true;
+            $methodCallReference = str_replace(ReferenceMarker::TEST, '', $methodCallReference);
+        }
+
+        [$class, $method] = explode('::', $methodCallReference);
+
+        return new self($class, $method, $isLocal, $isTest);
+    }
+
     public function __construct(
         private readonly string $class,
         private readonly string $method,
-        private readonly bool $isLocal
+        private readonly bool $isLocal,
+        private readonly bool $isTest,
     ) {
     }
 
@@ -26,5 +49,26 @@ final class MethodCallReference
     public function isLocal(): bool
     {
         return $this->isLocal;
+    }
+
+    public function isTest(): bool
+    {
+        return $this->isTest;
+    }
+
+    public function __toString(): string
+    {
+        $className = $this->getClass();
+        $methodName = $this->getMethod();
+
+        $methodCallReference = $className . '::' . $methodName;
+        if ($this->isLocal()) {
+            $methodCallReference = ReferenceMarker::LOCAL . $methodCallReference;
+        }
+        if ($this->isTest()) {
+            $methodCallReference = ReferenceMarker::TEST . $methodCallReference;
+        }
+
+        return $methodCallReference;
     }
 }

--- a/src/ValueObject/PropertyReference.php
+++ b/src/ValueObject/PropertyReference.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\ValueObject;
+
+use Stringable;
+use TomasVotruba\UnusedPublic\Enum\ReferenceMarker;
+
+final class PropertyReference implements Stringable
+{
+    public static function fromString(string $propertyReference): self
+    {
+        $isTest = false;
+        if (str_contains($propertyReference, ReferenceMarker::TEST)) {
+            $isTest = true;
+            $propertyReference = str_replace(ReferenceMarker::TEST, '', $propertyReference);
+        }
+
+        [$class, $property] = explode('::', $propertyReference);
+
+        return new self($class, $property, $isTest);
+    }
+
+    public function __construct(
+        private readonly string $class,
+        private readonly string $property,
+        private readonly bool $isTest,
+    ) {
+    }
+
+    public function getClass(): string
+    {
+        return $this->class;
+    }
+
+    public function getProperty(): string
+    {
+        return $this->property;
+    }
+
+    public function isTest(): bool
+    {
+        return $this->isTest;
+    }
+
+    public function __toString(): string
+    {
+        $className = $this->getClass();
+        $propertyName = $this->getProperty();
+
+        $propertyReference = $className . '::' . $propertyName;
+        if ($this->isTest()) {
+            $propertyReference = ReferenceMarker::TEST . $propertyReference;
+        }
+
+        return $propertyReference;
+    }
+}

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/LocallyUsedPublicInternalMethod.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/LocallyUsedPublicInternalMethod.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture;
+
+final class LocallyUsedPublicInternalMethod
+{
+    /**
+     * @internal
+     */
+    public function runHere()
+    {
+    }
+
+    private function run()
+    {
+        $this->runHere();
+    }
+}

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/LocalOnlyPublicClassMethodRuleTest.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/LocalOnlyPublicClassMethodRuleTest.php
@@ -48,7 +48,23 @@ final class LocalOnlyPublicClassMethodRuleTest extends RuleTestCase
             'runHere'
         );
 
-        yield [[__DIR__ . '/Fixture/LocallyUsedPublicMethod.php'], [[$errorMessage, 9, RuleTips::NARROW_SCOPE]]];
+        yield [
+            [
+                __DIR__ . '/Fixture/LocallyUsedPublicMethod.php',
+                __DIR__ . '/Source/TestCaseInternalMethodUser.php',
+            ],
+            [
+                [$errorMessage, 9, RuleTips::NARROW_SCOPE],
+            ],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/LocallyUsedPublicInternalMethod.php',
+                __DIR__ . '/Source/TestCaseInternalMethodUser.php',
+            ],
+            [],
+        ];
 
         $errorMessage = sprintf(
             LocalOnlyPublicClassMethodRule::ERROR_MESSAGE,

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/Source/TestCaseInternalMethodUser.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/Source/TestCaseInternalMethodUser.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Source;
+
+use PHPUnit\Framework\TestCase;
+use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture\LocallyUsedPublicInternalMethod;
+
+final class TestCaseUser extends TestCase
+{
+    private function go(LocallyusedPublicInternalMethod $locallyusedPublicInternalMethod): void
+    {
+        $locallyusedPublicInternalMethod->runHere();
+    }
+}

--- a/tests/Rules/UnusedPublicClassConstRule/Fixture/SkipUsedPublicConstantInSubclass.php
+++ b/tests/Rules/UnusedPublicClassConstRule/Fixture/SkipUsedPublicConstantInSubclass.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
 
-final class SkipUsedConstantInSubclass extends PublicConstant
+final class SkipUsedPublicConstantInSubclass extends PublicConstant
 {
 }

--- a/tests/Rules/UnusedPublicClassConstRule/Fixture/UnusedInternalClassPublicConstant.php
+++ b/tests/Rules/UnusedPublicClassConstRule/Fixture/UnusedInternalClassPublicConstant.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+/**
+ * @internal
+ */
+final class UnusedInternalClassPublicConstant
+{
+    public const UNUSED = 'not here';
+}

--- a/tests/Rules/UnusedPublicClassConstRule/Fixture/UnusedPublicInternalConstant.php
+++ b/tests/Rules/UnusedPublicClassConstRule/Fixture/UnusedPublicInternalConstant.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+final class UnusedPublicInternalConstant
+{
+    /**
+     * @internal
+     */
+    public const UNUSED = 'not here';
+}

--- a/tests/Rules/UnusedPublicClassConstRule/Fixture/UsedInternalClassPublicConstantInTestCaseOnly.php
+++ b/tests/Rules/UnusedPublicClassConstRule/Fixture/UsedInternalClassPublicConstantInTestCaseOnly.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+/**
+ * @internal
+ */
+final class UsedInternalClassPublicConstantInTestCaseOnly
+{
+    public const USE_ME = 'not here';
+}

--- a/tests/Rules/UnusedPublicClassConstRule/Fixture/UsedPublicInternalConstantInTestCaseOnly.php
+++ b/tests/Rules/UnusedPublicClassConstRule/Fixture/UsedPublicInternalConstantInTestCaseOnly.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+final class UsedPublicInternalConstantInTestCaseOnly
+{
+    /**
+     * @internal
+     */
+    public const USE_ME = 'not here';
+}

--- a/tests/Rules/UnusedPublicClassConstRule/Source/TestCaseInternalConstantUser.php
+++ b/tests/Rules/UnusedPublicClassConstRule/Source/TestCaseInternalConstantUser.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture;
+
+use PHPUnit\Framework\TestCase;
+
+final class TestCaseInternalConstantUser extends TestCase
+{
+    private function go()
+    {
+        $used1 = UsedPublicInternalConstantInTestCaseOnly::USE_ME;
+        $used2 = UsedInternalClassPublicConstantInTestCaseOnly::USE_ME;
+    }
+}

--- a/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
+++ b/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
@@ -15,8 +15,10 @@ use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\Rules\UnusedPublicClassConstRule;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\LocallyUsedPublicConstant;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\LocallyUsedPublicConstantByName;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\UnusedInternalClassPublicConstant;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\UnusedPublicConstant;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\UnusedPublicConstantFromInterface;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\UnusedPublicInternalConstant;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\UsedInTestCaseOnly;
 
 final class UnusedPublicClassConstRuleTest extends RuleTestCase
@@ -85,6 +87,50 @@ final class UnusedPublicClassConstRuleTest extends RuleTestCase
             __DIR__ . '/Fixture/UsedInTestCaseOnly.php',
             __DIR__ . '/Source/TestCaseUser.php',
         ], [[$errorMessage, 9, RuleTips::SOLUTION_MESSAGE]]];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/UsedPublicInternalConstantInTestCaseOnly.php',
+                __DIR__ . '/Source/TestCaseInternalConstantUser.php',
+            ],
+            [],
+        ];
+
+        $errorMessage = sprintf(
+            UnusedPublicClassConstRule::ERROR_MESSAGE,
+            UnusedPublicInternalConstant::class,
+            'UNUSED',
+        );
+        yield [
+            [
+                __DIR__ . '/Fixture/UnusedPublicInternalConstant.php',
+            ],
+            [
+                [$errorMessage, 12, RuleTips::SOLUTION_MESSAGE],
+            ],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/UsedInternalClassPublicConstantInTestCaseOnly.php',
+                __DIR__ . '/Source/TestCaseInternalConstantUser.php',
+            ],
+            [],
+        ];
+
+        $errorMessage = sprintf(
+            UnusedPublicClassConstRule::ERROR_MESSAGE,
+            UnusedInternalClassPublicConstant::class,
+            'UNUSED',
+        );
+        yield [
+            [
+                __DIR__ . '/Fixture/UnusedInternalClassPublicConstant.php',
+            ],
+            [
+                [$errorMessage, 12, RuleTips::SOLUTION_MESSAGE],
+            ],
+        ];
     }
 
     /**

--- a/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
+++ b/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
@@ -69,8 +69,12 @@ final class UnusedPublicClassConstRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/SkipApiPublicConstant.php'], []];
         yield [[__DIR__ . '/Fixture/SkipApiClassPublicConstant.php'], []];
         yield [[__DIR__ . '/Fixture/SkipUsedPublicConstant.php', __DIR__ . '/Source/ConstantUser.php'], []];
-        yield [[
-            __DIR__ . '/Fixture/SkipUsedConstantInSubclass.php', __DIR__ . '/Source/ConstantUserFromSubclass.php', ],
+        yield [
+            [
+                __DIR__ . '/Fixture/PublicConstant.php',
+                __DIR__ . '/Fixture/SkipUsedPublicConstantInSubclass.php',
+                __DIR__ . '/Source/ConstantUserFromSubclass.php',
+            ],
             [],
         ];
 

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/UnusedInternalClassPublicClassMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/UnusedInternalClassPublicClassMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+/**
+ * @internal
+ */
+final class UnusedInternalClassPublicClassMethod
+{
+    public function freeForAll()
+    {
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/UnusedPublicInternalClassMethod.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/UnusedPublicInternalClassMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+final class UnusedPublicInternalClassMethod
+{
+    /**
+     * @internal
+     */
+    public function freeForAll()
+    {
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/UsedInternalClassPublicClassMethodInTestCaseOnly.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/UsedInternalClassPublicClassMethodInTestCaseOnly.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+/**
+ * @internal
+ */
+final class UsedInternalClassPublicClassMethodInTestCaseOnly
+{
+    public function useMe()
+    {
+    }
+
+    public static function useMeStatic()
+    {
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/UsedPublicInternalClassMethodInTestCaseOnly.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/UsedPublicInternalClassMethodInTestCaseOnly.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+final class UsedPublicInternalClassMethodInTestCaseOnly
+{
+    /**
+     * @internal
+     */
+    public function useMe()
+    {
+    }
+
+    /**
+     * @internal
+     */
+    public static function useMeStatic()
+    {
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/Source/TestCaseInternalMethodUser.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Source/TestCaseInternalMethodUser.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source;
+
+use PHPUnit\Framework\TestCase;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\UsedInternalClassPublicClassMethodInTestCaseOnly;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\UsedPublicInternalClassMethodInTestCaseOnly;
+
+final class TestCaseUser extends TestCase
+{
+    private function go1(UsedPublicInternalClassMethodInTestCaseOnly $usedPublicInternalClassMethodInTestCaseOnly)
+    {
+        $usedPublicInternalClassMethodInTestCaseOnly->useMe();
+
+        UsedPublicInternalClassMethodInTestCaseOnly::useMeStatic();
+    }
+
+    private function go2(UsedInternalClassPublicClassMethodInTestCaseOnly $usedInternalClassPublicClassMethodInTestCaseOnly)
+    {
+        $usedInternalClassPublicClassMethodInTestCaseOnly->useMe();
+
+        UsedInternalClassPublicClassMethodInTestCaseOnly::useMeStatic();
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -22,6 +22,8 @@ use TomasVotruba\UnusedPublic\Rules\UnusedPublicClassMethodRule;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Interface\InterfaceWithExtraMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\StaticPublicMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\Tests\MethodForTests;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\UnusedInternalClassPublicClassMethod;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\UnusedPublicInternalClassMethod;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture\UsedInTestCaseOnly;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source\Caller2;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source\SomeEnum;
@@ -177,6 +179,51 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/plain.php', __DIR__ . '/Source/Caller1.php'], []];
         yield [[__DIR__ . '/Fixture/plain-call-user-func.php', __DIR__ . '/Source/Caller1.php'], []];
         yield [[__DIR__ . '/Fixture/SkipCrashBug89.php.inc'], []];
+
+        // internal
+        yield [
+            [
+                __DIR__ . '/Fixture/UsedPublicInternalClassMethodInTestCaseOnly.php',
+                __DIR__ . '/Source/TestCaseInternalMethodUser.php',
+            ],
+            [],
+        ];
+
+        $errorMessage = sprintf(
+            UnusedPublicClassMethodRule::ERROR_MESSAGE,
+            UnusedPublicInternalClassMethod::class,
+            'freeForAll',
+        );
+        yield [
+            [
+                __DIR__ . '/Fixture/UnusedPublicInternalClassMethod.php',
+            ],
+            [
+                [$errorMessage, 12, RuleTips::SOLUTION_MESSAGE],
+            ],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/UsedInternalClassPublicClassMethodInTestCaseOnly.php',
+                __DIR__ . '/Source/TestCaseInternalMethodUser.php',
+            ],
+            [],
+        ];
+
+        $errorMessage = sprintf(
+            UnusedPublicClassMethodRule::ERROR_MESSAGE,
+            UnusedInternalClassPublicClassMethod::class,
+            'freeForAll',
+        );
+        yield [
+            [
+                __DIR__ . '/Fixture/UnusedInternalClassPublicClassMethod.php',
+            ],
+            [
+                [$errorMessage, 12, RuleTips::SOLUTION_MESSAGE],
+            ],
+        ];
     }
 
     /**

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/UnusedInternalClassPublicProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/UnusedInternalClassPublicProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+/**
+ * @internal
+ */
+final class UnusedInternalClassPublicProperty
+{
+    public $property = 'public';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/UnusedPublicInternalProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/UnusedPublicInternalProperty.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+final class UnusedPublicInternalProperty
+{
+    /**
+     * @internal
+     */
+    public $property = 'public';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/UsedInternalClassPublicPropertyInTestCaseOnly.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/UsedInternalClassPublicPropertyInTestCaseOnly.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+/**
+ * @internal
+ */
+class UsedInternalClassPublicPropertyInTestCaseOnly
+{
+    public $property = 'public';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/UsedInternalSubclassPublicPropertyInTestCaseOnly.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/UsedInternalSubclassPublicPropertyInTestCaseOnly.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+class UsedInternalSubclassPublicPropertyInTestCaseOnly extends UsedInternalClassPublicPropertyInTestCaseOnly
+{
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/UsedPublicInternalPropertyInTestCaseOnly.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/UsedPublicInternalPropertyInTestCaseOnly.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+class UsedPublicInternalPropertyInTestCaseOnly
+{
+    /**
+     * @internal
+     */
+    public $property = 'public';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/UsedPublicInternalSubpropertyInTestCaseOnly.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/UsedPublicInternalSubpropertyInTestCaseOnly.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+class UsedPublicInternalSubpropertyInTestCaseOnly extends UsedPublicInternalPropertyInTestCaseOnly
+{
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-static-and-nonstatic.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-static-and-nonstatic.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicPropertyClass;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicStaticPropertyClass;
+
+$o = new PublicPropertyClass();
+$o->property = 'a value';
+
+PublicStaticPropertyClass::$staticProperty = 'a value';

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-superclass-static.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-superclass-static.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicStaticPropertySubclass;
+
+PublicStaticPropertySubclass::$staticProperty = 'a value';

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-superclass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/plain-superclass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicPropertySubclass;
+
+$o = new PublicPropertySubclass();
+$o->property = 'a value';

--- a/tests/Rules/UnusedPublicPropertyRule/Source/PublicPropertySubclass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/PublicPropertySubclass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class PublicPropertySubclass extends PublicPropertyClass
+{
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Source/PublicStaticPropertyClass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/PublicStaticPropertyClass.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class PublicStaticPropertyClass
+{
+    public $staticProperty = 'public static';
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Source/PublicStaticPropertySubclass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/PublicStaticPropertySubclass.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+class PublicStaticPropertySubclass extends PublicStaticPropertyClass
+{
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Source/TestCaseInternalPropertyUser.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/TestCaseInternalPropertyUser.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+use PHPUnit\Framework\TestCase;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\UsedInternalClassPublicPropertyInTestCaseOnly;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\UsedInternalSubclassPublicPropertyInTestCaseOnly;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\UsedPublicInternalPropertyInTestCaseOnly;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\UsedPublicInternalSubpropertyInTestCaseOnly;
+
+final class TestCaseInternalPropertyUser extends TestCase
+{
+    private function go1()
+    {
+        $o = new UsedPublicInternalPropertyInTestCaseOnly();
+        $o->property = 'a value';
+    }
+
+    private function go2()
+    {
+        $o = new UsedInternalClassPublicPropertyInTestCaseOnly();
+        $o->property = 'a value';
+    }
+
+    private function go3()
+    {
+        $o = new UsedPublicInternalSubpropertyInTestCaseOnly();
+        $o->property = 'a value';
+    }
+
+    private function go4()
+    {
+        $o = new UsedInternalSubclassPublicPropertyInTestCaseOnly();
+        $o->property = 'a value';
+    }
+}

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -104,6 +104,15 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
         ];
 
         yield [[__DIR__ . '/Fixture/plain.php', __DIR__ . '/Source/PublicPropertyClass.php'], []];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/plain-static-and-nonstatic.php',
+                __DIR__ . '/Source/PublicPropertyClass.php',
+                __DIR__ . '/Source/PublicStaticPropertyClass.php',
+            ],
+            [],
+        ];
     }
 
     /**

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -113,6 +113,24 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
             ],
             [],
         ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/plain-superclass.php',
+                __DIR__ . '/Source/PublicPropertyClass.php',
+                __DIR__ . '/Source/PublicPropertySubclass.php',
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/plain-superclass-static.php',
+                __DIR__ . '/Source/PublicStaticPropertyClass.php',
+                __DIR__ . '/Source/PublicStaticPropertySubclass.php',
+            ],
+            [],
+        ];
     }
 
     /**

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -18,6 +18,8 @@ use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\Ignor
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocallyUsedStaticProperty;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocallyUsedStaticPropertyViaStatic;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\LocalyUsedPublicProperty;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\UnusedInternalClassPublicProperty;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\UnusedPublicInternalProperty;
 use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\UsedInTestCaseOnly;
 
 final class UnusedPublicPropertyRuleTest extends RuleTestCase
@@ -128,6 +130,68 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
                 __DIR__ . '/Fixture/plain-superclass-static.php',
                 __DIR__ . '/Source/PublicStaticPropertyClass.php',
                 __DIR__ . '/Source/PublicStaticPropertySubclass.php',
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/UsedPublicInternalPropertyInTestCaseOnly.php',
+                __DIR__ . '/Source/TestCaseInternalPropertyUser.php',
+            ],
+            [],
+        ];
+
+        $errorMessage = sprintf(
+            UnusedPublicPropertyRule::ERROR_MESSAGE,
+            UnusedPublicInternalProperty::class,
+            'property',
+        );
+        yield [
+            [
+                __DIR__ . '/Fixture/UnusedPublicInternalProperty.php',
+            ],
+            [
+                [$errorMessage, 7, RuleTips::SOLUTION_MESSAGE],
+            ],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/UsedInternalClassPublicPropertyInTestCaseOnly.php',
+                __DIR__ . '/Source/TestCaseInternalPropertyUser.php',
+            ],
+            [],
+        ];
+
+        $errorMessage = sprintf(
+            UnusedPublicPropertyRule::ERROR_MESSAGE,
+            UnusedInternalClassPublicProperty::class,
+            'property',
+        );
+        yield [
+            [
+                __DIR__ . '/Fixture/UnusedInternalClassPublicProperty.php',
+            ],
+            [
+                [$errorMessage, 10, RuleTips::SOLUTION_MESSAGE],
+            ],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/UsedPublicInternalPropertyInTestCaseOnly.php',
+                __DIR__ . '/Fixture/UsedPublicInternalSubpropertyInTestCaseOnly.php',
+                __DIR__ . '/Source/TestCaseInternalPropertyUser.php',
+            ],
+            [],
+        ];
+
+        yield [
+            [
+                __DIR__ . '/Fixture/UsedInternalClassPublicPropertyInTestCaseOnly.php',
+                __DIR__ . '/Fixture/UsedInternalSubclassPublicPropertyInTestCaseOnly.php',
+                __DIR__ . '/Source/TestCaseInternalPropertyUser.php',
             ],
             [],
         ];


### PR DESCRIPTION
Please add support for `@internal` annotation.

Motivation:
Sometimes methods are made public only for testing purposes.
Such methods are never called from production code, but are called from test code.
Such methods are sometimes annotated with `@internal` to indicate to other developers that they should not be used in production code.

This pull request depends on #97 and #98, and I will resolve the conflict after that merge.