### PR TITLE
Skip local only public method, when used from test

### DIFF
--- a/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/SkipTestCaseUsedPublicMethod.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/SkipTestCaseUsedPublicMethod.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rules\LocalOnlyPublicClassMethodRule\Fixture;
+
+final class SkipTestCaseUsedPublicMethod
+{
+    public function runHere()
+    {
+    }
+
+    private function run()
+    {
+        $this->runHere();
+    }
+}

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/LocalOnlyPublicClassMethodRuleTest.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/LocalOnlyPublicClassMethodRuleTest.php
@@ -64,6 +64,7 @@ final class LocalOnlyPublicClassMethodRuleTest extends RuleTestCase
         );
         yield [[__DIR__ . '/Fixture/LocallyUsedEnumMethod.php'], [[$errorMessage, 12, RuleTips::NARROW_SCOPE]]];
         yield [[__DIR__ . '/Fixture/SkipPublicCallbackMethod.php'], []];
+        yield [[__DIR__ . '/Fixture/SkipTestCaseUsedPublicMethod.php'], []];
     }
 
     /**

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/Source/TestCaseUser.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/Source/TestCaseUser.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rules\LocalOnlyPublicClassMethodRule\Source;
+
+use PHPUnit\Framework\TestCase;
+use Rules\LocalOnlyPublicClassMethodRule\Fixture\SkipTestCaseUsedPublicMethod;
+
+final class TestCaseUser extends TestCase
+{
+    private function go(SkipTestCaseUsedPublicMethod $skipTestCaseUsedPublicMethod)
+    {
+        $skipTestCaseUsedPublicMethod->runHere();
+    }
+}


### PR DESCRIPTION
Sometimes methods are declared public, just to be easy testable.
from implementation side these might only be called privately.

I think we should not report such public methods, as these have valid calls from a test-case, as 
> Public method "%s::%s()" is used only locally and should be turned protected/private

because turning these methods private will lead to failling tests