### PR TITLE
Feature/allow usage of internal or required to skip checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ But what about public class elements?
 
 **How can we detect such element?**
 
-* find a e.g. public method
-* find all public method calls
-* compare those in simple diff
-* if the public method is not found, it probably unused
+-   find a e.g. public method
+-   find all public method calls
+-   compare those in simple diff
+-   if the public method is not found, it probably unused
 
 That's exactly what this package does.
 
@@ -92,7 +92,6 @@ Some methods are used only in TWIG or Blade templates, and could be reported fal
 
 How can we exclude them? Add your TWIG or Blade template directories in config to exclude methods names:
 
-
 ```neon
 # phpstan.neon
 parameters:
@@ -107,7 +106,7 @@ parameters:
 
 In some cases, the rules report false positives:
 
-* when used only in templates, apart Twig paths, it's not possible to detect them
+-   when used only in templates, apart Twig paths, it's not possible to detect them
 
 <br>
 
@@ -127,5 +126,31 @@ final class Book
     {
         return $this->name;
     }
+}
+```
+
+You can also use the `@required` or `@internal` to make it clearer in certain situations that you want the check skipped or that it is used internally. In this situation in Laravel, while the direct call is not present, it can be used as a property when [referencing relationships in Laravel Eloquent models](https://laravel.com/docs/11.x/eloquent-relationships#defining-relationships):
+
+```php
+<?php
+
+class User extends Model
+{
+    // ...
+
+    /**
+     * @internal
+     */
+    public $timestamps = false;
+
+    /**
+     * @required
+     */
+    public function post(): HasOne
+    {
+        return $this->hasOne(Post::class);
+    }
+
+    // ...
 }
 ```

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -26,6 +26,7 @@ services:
     - TomasVotruba\UnusedPublic\MethodTypeDetector
     - TomasVotruba\UnusedPublic\ClassTypeDetector
     - TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer
+    - TomasVotruba\UnusedPublic\InternalOrRequiredStmtAnalyzer
     - TomasVotruba\UnusedPublic\ClassMethodCallReferenceResolver
     - TomasVotruba\UnusedPublic\CollectorMapper\MethodCallCollectorMapper
     # templates

--- a/src/ApiDocStmtAnalyzer.php
+++ b/src/ApiDocStmtAnalyzer.php
@@ -15,7 +15,7 @@ final class ApiDocStmtAnalyzer
     {
         if ($classReflection->getResolvedPhpDoc() instanceof ResolvedPhpDocBlock) {
             $resolvedPhpDoc = $classReflection->getResolvedPhpDoc();
-            if (str_contains($resolvedPhpDoc->getPhpDocString(), '@api')) {
+            if ($this->isApiDocComment($resolvedPhpDoc->getPhpDocString())) {
                 return true;
             }
         }

--- a/src/Collectors/PublicClassLikeConstCollector.php
+++ b/src/Collectors/PublicClassLikeConstCollector.php
@@ -11,6 +11,7 @@ use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
 use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\InternalOrRequiredStmtAnalyzer;
 
 /**
  * @implements Collector<ClassConst, array<array{class-string, string, int}>>
@@ -19,6 +20,7 @@ final class PublicClassLikeConstCollector implements Collector
 {
     public function __construct(
         private readonly ApiDocStmtAnalyzer $apiDocStmtAnalyzer,
+        private readonly InternalOrRequiredStmtAnalyzer $internalOrRequiredStmtAnalyzer,
         private readonly Configuration $configuration,
     ) {
     }
@@ -48,6 +50,10 @@ final class PublicClassLikeConstCollector implements Collector
         }
 
         if ($this->apiDocStmtAnalyzer->isApiDoc($node, $classReflection)) {
+            return null;
+        }
+
+        if ($this->internalOrRequiredStmtAnalyzer->isInternalOrRequired($node, $classReflection)) {
             return null;
         }
 

--- a/src/Collectors/PublicClassMethodCollector.php
+++ b/src/Collectors/PublicClassMethodCollector.php
@@ -11,6 +11,7 @@ use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
 use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\InternalOrRequiredStmtAnalyzer;
 use TomasVotruba\UnusedPublic\MethodTypeDetector;
 use TomasVotruba\UnusedPublic\PublicClassMethodMatcher;
 
@@ -39,6 +40,7 @@ final class PublicClassMethodCollector implements Collector
 
     public function __construct(
         private readonly ApiDocStmtAnalyzer $apiDocStmtAnalyzer,
+        private readonly InternalOrRequiredStmtAnalyzer $internalOrRequiredStmtAnalyzer,
         private readonly PublicClassMethodMatcher $publicClassMethodMatcher,
         private readonly MethodTypeDetector $methodTypeDetector,
         private readonly Configuration $configuration,
@@ -74,6 +76,10 @@ final class PublicClassMethodCollector implements Collector
         }
 
         if ($this->apiDocStmtAnalyzer->isApiDoc($node, $classReflection)) {
+            return null;
+        }
+
+        if ($this->internalOrRequiredStmtAnalyzer->isInternalOrRequired($node, $classReflection)) {
             return null;
         }
 

--- a/src/Collectors/PublicPropertyCollector.php
+++ b/src/Collectors/PublicPropertyCollector.php
@@ -4,15 +4,16 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Collectors;
 
-use Livewire\Component;
 use PhpParser\Node;
-use PhpParser\Node\Stmt\Class_;
+use Livewire\Component;
 use PHPStan\Analyser\Scope;
-use PHPStan\Collectors\Collector;
 use PHPStan\Node\InClassNode;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
-use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
+use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
+use TomasVotruba\UnusedPublic\InternalOrRequiredStmtAnalyzer;
 
 /**
  * @implements Collector<InClassNode, array<array{class-string, string, int}>>
@@ -26,6 +27,7 @@ final class PublicPropertyCollector implements Collector
 
     public function __construct(
         private readonly ApiDocStmtAnalyzer $apiDocStmtAnalyzer,
+        private readonly InternalOrRequiredStmtAnalyzer $internalOrRequiredStmtAnalyzer,
         private readonly Configuration $configuration
     ) {
     }
@@ -115,6 +117,8 @@ final class PublicPropertyCollector implements Collector
             }
         }
 
-        return $this->apiDocStmtAnalyzer->isApiDoc($class, $classReflection);
+        return
+            $this->apiDocStmtAnalyzer->isApiDoc($class, $classReflection) ||
+            $this->internalOrRequiredStmtAnalyzer->isInternalOrRequired($class, $classReflection);
     }
 }

--- a/src/Enum/RuleTips.php
+++ b/src/Enum/RuleTips.php
@@ -10,7 +10,7 @@ final class RuleTips
      * @todo this wont make sense anymore, as there will be a rule to make method private/protected
      * @var string
      */
-    public const SOLUTION_MESSAGE = 'Either reduce visibility or annotate it or its class with @api';
+    public const SOLUTION_MESSAGE = 'Either reduce visibility or annotate it or its class with @api, @internal, or @required';
 
     /**
      * @var string

--- a/src/InternalOrRequiredStmtAnalyzer.php
+++ b/src/InternalOrRequiredStmtAnalyzer.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Stmt;
+use PHPStan\PhpDoc\ResolvedPhpDocBlock;
+use PHPStan\Reflection\ClassReflection;
+
+final class InternalOrRequiredStmtAnalyzer
+{
+    public function isInternalOrRequired(Stmt $stmt, ClassReflection $classReflection): bool
+    {
+        if ($classReflection->getResolvedPhpDoc() instanceof ResolvedPhpDocBlock) {
+            $resolvedPhpDoc = $classReflection->getResolvedPhpDoc();
+            if ($this->isInternalOrRequiredComment($resolvedPhpDoc->getPhpDocString())) {
+                return true;
+            }
+        }
+
+        $docComment = $stmt->getDocComment();
+        if (! $docComment instanceof Doc) {
+            return false;
+        }
+
+        return $this->isInternalOrRequiredComment($docComment->getText());
+    }
+
+    public function isInternalOrRequiredComment(string $docComment): bool
+    {
+        return str_contains(strtolower($docComment), '@required') || str_contains(strtolower($docComment), '@internal');
+    }
+}


### PR DESCRIPTION
In certain scenarios, like overriding model properties like `timestamps` it is flagged by PHPStan. This is likely because the `timestamps` property is set via a trait? Not sure. Either way, the easy solution would be to tag `@api` to the property override. 

I imagined introducing skips for `@internal` which works best for properties like `$timestamps` or `@required` which could work for model method definitions, would be more fitting.

Thought about allowing the user also define which tags they want to use for ignoring but that seemed like an overkill.