### PR TITLE
Added test for JsonSerialize

### DIFF
--- a/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipJsonSerialize.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/Fixture/SkipJsonSerialize.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Fixture;
+
+class SkipJsonSerialize implements \JsonSerializable {
+    public function jsonSerialize() : array {
+        return [];
+    }
+}

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -175,6 +175,8 @@ final class UnusedPublicClassMethodRuleTest extends RuleTestCase
         yield [[__DIR__ . '/Fixture/plain.php', __DIR__ . '/Source/Caller1.php'], []];
         yield [[__DIR__ . '/Fixture/plain-call-user-func.php', __DIR__ . '/Source/Caller1.php'], []];
         yield [[__DIR__ . '/Fixture/SkipCrashBug89.php.inc'], []];
+
+        yield [[__DIR__ . '/Fixture/SkipJsonSerialize.php'], []];
     }
 
     /**


### PR DESCRIPTION
just adding a test-case to make sure we won't regress marking php-src native interface methods as unused