### PR TITLE
Declare missing nette/utils dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "php": "^8.2",
         "phpstan/phpstan": "^1.10",
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^1.11",
+        "nette/utils": "^4.0"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.3",


### PR DESCRIPTION
nette/utils is required https://github.com/TomasVotruba/unused-public/blob/f60fcb120016f41a12055384bab978b08a5d42bc/src/Rules/UnusedPublicClassMethodRule.php#L7

fixes

```
➜  phpunit git:(phpstan) ✗ vendor/bin/phpstan
Note: Using configuration file /Users/staabm/workspace/phpunit/phpstan.neon.
 904/904 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

PHP Fatal error:  Uncaught Error: Class "Nette\Utils\Arrays" not found in /Users/staabm/workspace/phpunit/vendor/tomasvotruba/unused-public/src/Rules/UnusedPublicClassMethodRule.php:86
Stack trace:
#0 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseApplication.php(172): TomasVotruba\UnusedPublic\Rules\UnusedPublicClassMethodRule->processNode(Object(PHPStan\Node\CollectedDataNode), Object(PHPStan\Analyser\MutatingScope))
#1 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseApplication.php(136): PHPStan\Command\AnalyseApplication->getCollectedDataErrors(Array, false)
#2 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseCommand.php(202): PHPStan\Command\AnalyseApplication->analyse(Array, false, Object(PHPStan\Command\Symfony\SymfonyOutput), Object(PHPStan\Command\Symfony\SymfonyOutput), false, false, '/Users/staabm/w...', Array, Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput))
#3 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Command/Command.php(259): PHPStan\Command\AnalyseCommand->execute(Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Output\ConsoleOutput))
#4 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(870): _PHPStan_7961f7ae1\Symfony\Component\Console\Command\Command->run(Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Output\ConsoleOutput))
#5 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(261): _PHPStan_7961f7ae1\Symfony\Component\Console\Application->doRunCommand(Object(PHPStan\Command\AnalyseCommand), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Output\ConsoleOutput))
#6 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(157): _PHPStan_7961f7ae1\Symfony\Component\Console\Application->doRun(Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Output\ConsoleOutput))
#7 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan(124): _PHPStan_7961f7ae1\Symfony\Component\Console\Application->run()
#8 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan(125): _PHPStan_7961f7ae1\{closure}()
#9 /Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan(8): require('phar:///Users/s...')
#10 /Users/staabm/workspace/phpunit/vendor/bin/phpstan(119): include('/Users/staabm/w...')
#11 {main}
  thrown in /Users/staabm/workspace/phpunit/vendor/tomasvotruba/unused-public/src/Rules/UnusedPublicClassMethodRule.php on line 86
  ```