### PR TITLE
Fixed nette/utils indirect dependency

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -36,6 +36,10 @@ jobs:
                         name: 'Check Active Classes'
                         run: vendor/bin/class-leak check src --ansi
 
+                    -
+                        name: 'Detect composer dependency issues'
+                        run: vendor/bin/composer-dependency-analyser
+
         name: ${{ matrix.actions.name }}
         runs-on: ubuntu-latest
 

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types = 1);
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+$config = new Configuration();
+
+return $config
+    ->ignoreErrorsOnPackage('nikic/php-parser', [ErrorType::DEV_DEPENDENCY_IN_PROD]) // prepared test tooling
+    ->ignoreErrorsOnPaths([
+        __DIR__ . '/tests',
+    ], [ErrorType::UNKNOWN_CLASS]);

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -6,7 +6,7 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 $config = new Configuration();
 
 return $config
-    ->ignoreErrorsOnPackage('nikic/php-parser', [ErrorType::DEV_DEPENDENCY_IN_PROD]) // prepared test tooling
+    ->ignoreErrorsOnPackage('nikic/php-parser', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     ->ignoreErrorsOnPaths([
         __DIR__ . '/tests',
     ], [ErrorType::UNKNOWN_CLASS]);

--- a/composer-dependency-analyser.php
+++ b/composer-dependency-analyser.php
@@ -6,7 +6,6 @@ use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 $config = new Configuration();
 
 return $config
-    ->ignoreErrorsOnPackage('nikic/php-parser', [ErrorType::DEV_DEPENDENCY_IN_PROD])
     ->ignoreErrorsOnPaths([
         __DIR__ . '/tests',
     ], [ErrorType::UNKNOWN_CLASS]);

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "tomasvotruba/cognitive-complexity": "^0.2.2",
         "tomasvotruba/type-coverage": "^0.2",
         "symplify/easy-ci": "^12.0",
-        "nikic/php-parser": "^4.19"
+        "nikic/php-parser": "^4.19",
+        "shipmonk/composer-dependency-analyser": "^1.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "require": {
         "php": "^8.2",
         "phpstan/phpstan": "^1.10",
-        "webmozart/assert": "^1.11"
+        "webmozart/assert": "^1.11",
+        "nikic/php-parser": "^4.19"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.3",
@@ -19,7 +20,6 @@
         "tomasvotruba/cognitive-complexity": "^0.2.2",
         "tomasvotruba/type-coverage": "^0.2",
         "symplify/easy-ci": "^12.0",
-        "nikic/php-parser": "^4.19",
         "shipmonk/composer-dependency-analyser": "^1.5"
     },
     "autoload": {

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Rules;
 
-use Nette\Utils\Arrays;
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
 use PHPStan\Node\CollectedDataNode;
@@ -18,6 +17,7 @@ use TomasVotruba\UnusedPublic\Enum\RuleTips;
 use TomasVotruba\UnusedPublic\NodeCollectorExtractor;
 use TomasVotruba\UnusedPublic\Templates\TemplateMethodCallsProvider;
 use TomasVotruba\UnusedPublic\Templates\UsedMethodAnalyzer;
+use TomasVotruba\UnusedPublic\Utils\Arrays;
 use TomasVotruba\UnusedPublic\Utils\Strings;
 
 /**


### PR DESCRIPTION
fixes

```
➜  phpunit git:(phpstan) ✗ vendor/bin/phpstan
Note: Using configuration file /Users/staabm/workspace/phpunit/phpstan.neon.
 904/904 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

PHP Fatal error:  Uncaught Error: Class "Nette\Utils\Arrays" not found in /Users/staabm/workspace/phpunit/vendor/tomasvotruba/unused-public/src/Rules/UnusedPublicClassMethodRule.php:86
Stack trace:
#0 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseApplication.php(172): TomasVotruba\UnusedPublic\Rules\UnusedPublicClassMethodRule->processNode(Object(PHPStan\Node\CollectedDataNode), Object(PHPStan\Analyser\MutatingScope))
#1 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseApplication.php(136): PHPStan\Command\AnalyseApplication->getCollectedDataErrors(Array, false)
#2 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/src/Command/AnalyseCommand.php(202): PHPStan\Command\AnalyseApplication->analyse(Array, false, Object(PHPStan\Command\Symfony\SymfonyOutput), Object(PHPStan\Command\Symfony\SymfonyOutput), false, false, '/Users/staabm/w...', Array, Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput))
#3 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Command/Command.php(259): PHPStan\Command\AnalyseCommand->execute(Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Output\ConsoleOutput))
#4 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(870): _PHPStan_7961f7ae1\Symfony\Component\Console\Command\Command->run(Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Output\ConsoleOutput))
#5 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(261): _PHPStan_7961f7ae1\Symfony\Component\Console\Application->doRunCommand(Object(PHPStan\Command\AnalyseCommand), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Output\ConsoleOutput))
#6 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/vendor/symfony/console/Application.php(157): _PHPStan_7961f7ae1\Symfony\Component\Console\Application->doRun(Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Input\ArgvInput), Object(_PHPStan_7961f7ae1\Symfony\Component\Console\Output\ConsoleOutput))
#7 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan(124): _PHPStan_7961f7ae1\Symfony\Component\Console\Application->run()
#8 phar:///Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan.phar/bin/phpstan(125): _PHPStan_7961f7ae1\{closure}()
#9 /Users/staabm/workspace/phpunit/vendor/phpstan/phpstan/phpstan(8): require('phar:///Users/s...')
#10 /Users/staabm/workspace/phpunit/vendor/bin/phpstan(119): include('/Users/staabm/w...')
#11 {main}
  thrown in /Users/staabm/workspace/phpunit/vendor/tomasvotruba/unused-public/src/Rules/UnusedPublicClassMethodRule.php on line 86
  ```