### PR TITLE
add phpstan error identifiers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.2",
-        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan": "^1.11",
         "webmozart/assert": "^1.11",
         "nikic/php-parser": "^4.19"
     },

--- a/src/Rules/LocalOnlyPublicClassMethodRule.php
+++ b/src/Rules/LocalOnlyPublicClassMethodRule.php
@@ -90,6 +90,7 @@ final readonly class LocalOnlyPublicClassMethodRule implements Rule
                     ->file($filePath)
                     ->line($line)
                     ->tip(RuleTips::NARROW_SCOPE)
+                    ->identifier('public.method.unused')
                     ->build();
             }
         }

--- a/src/Rules/RelativeUnusedPublicClassMethodRule.php
+++ b/src/Rules/RelativeUnusedPublicClassMethodRule.php
@@ -139,6 +139,7 @@ final readonly class RelativeUnusedPublicClassMethodRule implements Rule
                 $ruleErrors[] = RuleErrorBuilder::message($errorMessage)
                     ->file($filePath)
                     ->line($line)
+                    ->identifier('public.method.unused')
                     ->build();
             }
         }

--- a/src/Rules/UnusedPublicClassConstRule.php
+++ b/src/Rules/UnusedPublicClassConstRule.php
@@ -84,6 +84,7 @@ final readonly class UnusedPublicClassConstRule implements Rule
                         ->file($filePath)
                         ->line($line)
                         ->tip(RuleTips::SOLUTION_MESSAGE)
+                        ->identifier('public.classConstant.unused')
                         ->build();
                 }
             }

--- a/src/Rules/UnusedPublicClassMethodRule.php
+++ b/src/Rules/UnusedPublicClassMethodRule.php
@@ -90,6 +90,7 @@ final readonly class UnusedPublicClassMethodRule implements Rule
                     ->file($filePath)
                     ->line($line)
                     ->tip(RuleTips::SOLUTION_MESSAGE)
+                    ->identifier('public.method.unused')
                     ->build();
             }
         }

--- a/src/Rules/UnusedPublicPropertyRule.php
+++ b/src/Rules/UnusedPublicPropertyRule.php
@@ -74,6 +74,7 @@ final readonly class UnusedPublicPropertyRule implements Rule
                         ->file($filePath)
                         ->line($line)
                         ->tip(RuleTips::SOLUTION_MESSAGE)
+                        ->identifier('public.property.unused')
                         ->build();
                 }
             }


### PR DESCRIPTION
For easier handling of ignores, PHPStan 1.11 has added error identifiers.

This PR adds them to the various reports generated by the `unused-public` extension.

As far as I can tell, the built-in testing framework for rules doesn't yet support error identifiers and thus I can't really provide test-cases for these. Correct me if I'm wrong and I'll gladly add test-cases.