### PR TITLE
Detect public properties used via Subclass

### DIFF
--- a/src/Collectors/PublicPropertyFetchCollector.php
+++ b/src/Collectors/PublicPropertyFetchCollector.php
@@ -62,7 +62,12 @@ final readonly class PublicPropertyFetchCollector implements Collector
         $propertyFetcherType = $scope->getType($node->var);
         foreach($propertyFetcherType->getObjectClassReflections() as $classReflection) {
             $propertyName = $node->name->toString();
-            $result[] = $classReflection->getName() . '::' . $propertyName;
+
+            if (!$classReflection->hasProperty($propertyName)) {
+                continue;
+            }
+            $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+            $result[] = $propertyReflection->getDeclaringClass()->getName() . '::' . $propertyName;
         }
 
         return $result;

--- a/src/Collectors/PublicStaticPropertyFetchCollector.php
+++ b/src/Collectors/PublicStaticPropertyFetchCollector.php
@@ -63,9 +63,14 @@ final readonly class PublicStaticPropertyFetchCollector implements Collector
             $classType = $scope->getType($node->class);
         }
         $result = [];
-        foreach($classType->getObjectClassNames() as $className) {
+        foreach($classType->getObjectClassReflections() as $classReflection) {
             $propertyName = $node->name->toString();
-            $result[] = $className . '::' . $propertyName;
+
+            if (!$classReflection->hasProperty($propertyName)) {
+                continue;
+            }
+            $propertyReflection = $classReflection->getProperty($propertyName, $scope);
+            $result[] = $propertyReflection->getDeclaringClass()->getName() . '::' . $propertyName;
         }
 
         return $result;

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/PropertyUsedViaSubClass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/PropertyUsedViaSubClass.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+class UseBaseClassViaSubClass
+{
+    private SubClass $prop;
+
+    protected function doFoo() {
+        $this->prop->x = 1;
+    }
+}
+
+class SubClass extends BaseClass
+{
+}
+
+class BaseClass
+{
+    public int $x;
+}

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/StaticPropertyUsedViaSubClass.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/StaticPropertyUsedViaSubClass.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
 
-class PropertyUsedViaSubClass
+class StaticPropertyUsedViaSubClass
 {
     private SubClass $prop;
 
     protected function doFoo() {
-        $this->prop->x = 1;
+        $this->prop::$x = 1;
     }
 }
 
@@ -19,5 +19,5 @@ class SubClass extends BaseClass
 
 class BaseClass
 {
-    public int $x;
+    static public int $x;
 }

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/StaticUsedInUnionA.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/StaticUsedInUnionA.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rules\UnusedPublicPropertyRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
 
 class StaticUsedInUnionA {
     static public float $amount;

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/StaticUsedInUnionB.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/StaticUsedInUnionB.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Rules\UnusedPublicPropertyRule\Fixture;
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
 
 class StaticUsedInUnionB {
     static public float $amount;

--- a/tests/Rules/UnusedPublicPropertyRule/Source/StaticUsedInUnion.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/StaticUsedInUnion.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
 
-use Rules\UnusedPublicPropertyRule\Fixture\StaticUsedInUnionA;
-use Rules\UnusedPublicPropertyRule\Fixture\StaticUsedInUnionB;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\StaticUsedInUnionA;
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\StaticUsedInUnionB;
 
 function doFooBar(StaticUsedInUnionA|StaticUsedInUnionB $aOrB): void {
     echo $aOrB::$amount;

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -32,6 +32,7 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
     public static function provideData(): Iterator
     {
         yield [[__DIR__ . '/Fixture/PropertyUsedViaSubClass.php'], []];
+        yield [[__DIR__ . '/Fixture/StaticPropertyUsedViaSubClass.php'], []];
 
         $errorMessage = sprintf(UnusedPublicPropertyRule::ERROR_MESSAGE, LocalyUsedPublicProperty::class, 'name');
         yield [[__DIR__ . '/Fixture/LocalyUsedPublicProperty.php'],

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -31,6 +31,8 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
 
     public static function provideData(): Iterator
     {
+        yield [[__DIR__ . '/Fixture/PropertyUsedViaSubClass.php'], []];
+
         $errorMessage = sprintf(UnusedPublicPropertyRule::ERROR_MESSAGE, LocalyUsedPublicProperty::class, 'name');
         yield [[__DIR__ . '/Fixture/LocalyUsedPublicProperty.php'],
             [[$errorMessage, 7, RuleTips::SOLUTION_MESSAGE]], ];


### PR DESCRIPTION
Utilize the declaring class, like we already do in ClassConstFetchCollector