### PR TITLE
Reduce memory consumption of collectors

### DIFF
--- a/src/Collectors/Callable_/AttributeCallableCollector.php
+++ b/src/Collectors/Callable_/AttributeCallableCollector.php
@@ -17,7 +17,7 @@ use TomasVotruba\UnusedPublic\Configuration;
 use TomasVotruba\UnusedPublic\ValueObject\ClassAndMethodArrayExprs;
 
 /**
- * @implements Collector<AttributeGroup, array<string>|null>
+ * @implements Collector<AttributeGroup, non-empty-array<string>|null>
  */
 final readonly class AttributeCallableCollector implements Collector
 {

--- a/src/Collectors/Callable_/CallUserFuncCollector.php
+++ b/src/Collectors/Callable_/CallUserFuncCollector.php
@@ -15,7 +15,7 @@ use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<FuncCall, array<string>|null>
+ * @implements Collector<FuncCall, non-empty-array<string>|null>
  */
 final readonly class CallUserFuncCollector implements Collector
 {

--- a/src/Collectors/ClassConstFetchCollector.php
+++ b/src/Collectors/ClassConstFetchCollector.php
@@ -15,7 +15,7 @@ use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<ClassConstFetch, string[]>
+ * @implements Collector<ClassConstFetch, non-empty-array<string>|null>
  */
 final readonly class ClassConstFetchCollector implements Collector
 {
@@ -32,12 +32,12 @@ final readonly class ClassConstFetchCollector implements Collector
 
     /**
      * @param ClassConstFetch $node
-     * @return string[]|null
+     * @return non-empty-array<string>|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
         if (! $this->configuration->isUnusedConstantsEnabled()) {
-            return [];
+            return null;
         }
 
         if (! $node->class instanceof Name) {

--- a/src/Collectors/FormTypeClassCollector.php
+++ b/src/Collectors/FormTypeClassCollector.php
@@ -14,7 +14,7 @@ use TomasVotruba\UnusedPublic\Configuration;
 
 /**
  * Match Symfony data_class element in forms types, as those use magic setters/getters
- * @implements Collector<ArrayItem, array<string>|null>
+ * @implements Collector<ArrayItem, non-empty-array<string>|null>
  */
 final readonly class FormTypeClassCollector implements Collector
 {
@@ -30,7 +30,7 @@ final readonly class FormTypeClassCollector implements Collector
 
     /**
      * @param ArrayItem $node
-     * @return string[]|null
+     * @return non-empty-array<string>|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {

--- a/src/Collectors/MethodCall/MethodCallCollector.php
+++ b/src/Collectors/MethodCall/MethodCallCollector.php
@@ -17,7 +17,7 @@ use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<MethodCall, array<string>|null>
+ * @implements Collector<MethodCall, non-empty-array<string>|null>
  */
 final readonly class MethodCallCollector implements Collector
 {

--- a/src/Collectors/MethodCall/MethodCallableCollector.php
+++ b/src/Collectors/MethodCall/MethodCallableCollector.php
@@ -16,7 +16,7 @@ use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<MethodCallableNode, array<string>|null>
+ * @implements Collector<MethodCallableNode, non-empty-array<string>|null>
  */
 final readonly class MethodCallableCollector implements Collector
 {

--- a/src/Collectors/PublicClassLikeConstCollector.php
+++ b/src/Collectors/PublicClassLikeConstCollector.php
@@ -13,7 +13,7 @@ use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<ClassConst, array<array{class-string, string, int}>>
+ * @implements Collector<ClassConst, non-empty-array<array{class-string, string, int}>|null>
  */
 final readonly class PublicClassLikeConstCollector implements Collector
 {
@@ -30,12 +30,12 @@ final readonly class PublicClassLikeConstCollector implements Collector
 
     /**
      * @param ClassConst $node
-     * @return array<array{class-string, string, int}>|null
+     * @return non-empty-array<array{class-string, string, int}>|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
         if (! $this->configuration->isUnusedConstantsEnabled()) {
-            return [];
+            return null;
         }
 
         if (! $node->isPublic()) {
@@ -54,6 +54,10 @@ final readonly class PublicClassLikeConstCollector implements Collector
         $constantNames = [];
         foreach ($node->consts as $constConst) {
             $constantNames[] = [$classReflection->getName(), $constConst->name->toString(), $node->getLine()];
+        }
+
+        if ([] === $constantNames) {
+            return null;
         }
 
         return $constantNames;

--- a/src/Collectors/PublicPropertyCollector.php
+++ b/src/Collectors/PublicPropertyCollector.php
@@ -15,7 +15,7 @@ use TomasVotruba\UnusedPublic\ApiDocStmtAnalyzer;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<InClassNode, array<array{class-string, string, int}>>
+ * @implements Collector<InClassNode, non-empty-array<array{class-string, string, int}>>
  */
 final readonly class PublicPropertyCollector implements Collector
 {
@@ -40,7 +40,7 @@ final readonly class PublicPropertyCollector implements Collector
 
     /**
      * @param InClassNode $node
-     * @return array<array{string, string, int}>|null
+     * @return non-empty-array<array{string, string, int}>|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
@@ -77,6 +77,10 @@ final readonly class PublicPropertyCollector implements Collector
 
                 $publicPropertyNames[] = [$classReflection->getName(), $propertyName, $node->getLine()];
             }
+        }
+
+        if ($publicPropertyNames === []) {
+            return null;
         }
 
         return $publicPropertyNames;

--- a/src/Collectors/PublicPropertyFetchCollector.php
+++ b/src/Collectors/PublicPropertyFetchCollector.php
@@ -15,7 +15,7 @@ use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<PropertyFetch, string[]>
+ * @implements Collector<PropertyFetch, non-empty-array<string>|null>
  */
 final readonly class PublicPropertyFetchCollector implements Collector
 {
@@ -35,7 +35,7 @@ final readonly class PublicPropertyFetchCollector implements Collector
 
     /**
      * @param PropertyFetch $node
-     * @return string[]|null
+     * @return non-empty-array<string>|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
@@ -68,6 +68,10 @@ final readonly class PublicPropertyFetchCollector implements Collector
 
             $propertyReflection = $classReflection->getProperty($propertyName, $scope);
             $result[] = $propertyReflection->getDeclaringClass()->getName() . '::' . $propertyName;
+        }
+
+        if ($result === []) {
+            return null;
         }
 
         return $result;

--- a/src/Collectors/PublicStaticPropertyFetchCollector.php
+++ b/src/Collectors/PublicStaticPropertyFetchCollector.php
@@ -15,7 +15,7 @@ use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<StaticPropertyFetch, string[]>
+ * @implements Collector<StaticPropertyFetch, non-empty-array<string>|null>
  */
 final readonly class PublicStaticPropertyFetchCollector implements Collector
 {
@@ -32,7 +32,7 @@ final readonly class PublicStaticPropertyFetchCollector implements Collector
 
     /**
      * @param StaticPropertyFetch $node
-     * @return string[]|null
+     * @return non-empty-array<string>|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {
@@ -71,6 +71,10 @@ final readonly class PublicStaticPropertyFetchCollector implements Collector
 
             $propertyReflection = $classReflection->getProperty($propertyName, $scope);
             $result[] = $propertyReflection->getDeclaringClass()->getName() . '::' . $propertyName;
+        }
+
+        if ($result === []) {
+            return null;
         }
 
         return $result;

--- a/src/Collectors/StaticCall/StaticMethodCallCollector.php
+++ b/src/Collectors/StaticCall/StaticMethodCallCollector.php
@@ -15,7 +15,7 @@ use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<StaticCall, array<string>|null>
+ * @implements Collector<StaticCall, non-empty-array<string>|null>
  */
 final readonly class StaticMethodCallCollector implements Collector
 {
@@ -32,7 +32,7 @@ final readonly class StaticMethodCallCollector implements Collector
 
     /**
      * @param StaticCall $node
-     * @return string[]|null
+     * @return non-empty-array<string>|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {

--- a/src/Collectors/StaticCall/StaticMethodCallableCollector.php
+++ b/src/Collectors/StaticCall/StaticMethodCallableCollector.php
@@ -15,7 +15,7 @@ use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
- * @implements Collector<StaticMethodCallableNode, array<string>|null>
+ * @implements Collector<StaticMethodCallableNode, non-empty-array<string>|null>
  */
 final readonly class StaticMethodCallableCollector implements Collector
 {
@@ -32,7 +32,7 @@ final readonly class StaticMethodCallableCollector implements Collector
 
     /**
      * @param StaticMethodCallableNode $node
-     * @return string[]|null
+     * @return non-empty-array<string>|null
      */
     public function processNode(Node $node, Scope $scope): ?array
     {

--- a/src/Rules/UnusedPublicClassConstRule.php
+++ b/src/Rules/UnusedPublicClassConstRule.php
@@ -67,6 +67,10 @@ final readonly class UnusedPublicClassConstRule implements Rule
 
         foreach ($publicClassLikeConstCollector as $filePath => $declarationsGroups) {
             foreach ($declarationsGroups as $declarationGroup) {
+                if ($declarationGroup === null) {
+                    continue;
+                }
+                
                 foreach ($declarationGroup as [$className, $constantName, $line]) {
                     if ($this->isClassConstantUsed(
                         $className,


### PR DESCRIPTION
a collector should either return a valid result or `null` - because the returned value is persisted in PHPStan result cache (except for `null`). therefore you should not return things like `[]`, as this would get serialized per AST node your collector works on.

thats something I learned today and in one of our projects it lead to out-of-memory fatal errors.

for in-detail context see https://github.com/phpstan/phpstan/discussions/11701#discussioncomment-10660711