### PR TITLE
Update to PHPStan 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,11 @@
         "phpstan/extension-installer": "^1.4",
         "tracy/tracy": "^2.10",
         "symplify/easy-coding-standard": "^12.3",
-        "rector/rector": "^1.2.5",
+        "rector/rector": "^2.0.0-rc1",
         "phpunit/phpunit": "^10.5",
         "tomasvotruba/class-leak": "^0.2.11",
-        "tomasvotruba/type-coverage": "^0.3",
         "symplify/easy-ci": "^12.1",
-        "shipmonk/composer-dependency-analyser": "^1.7",
-        "symplify/phpstan-rules": "^13.0"
+        "shipmonk/composer-dependency-analyser": "^1.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.2",
-        "phpstan/phpstan": "^1.12",
+        "phpstan/phpstan": "^2.0",
         "webmozart/assert": "^1.11",
-        "nikic/php-parser": "^4.19"
+        "nikic/php-parser": "^5.0"
     },
     "require-dev": {
         "phpstan/extension-installer": "^1.4",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,8 +20,3 @@ parameters:
     ignoreErrors:
         -
             identifier: missingType.generics
-
-        # overly detailed
-        -
-            message: '#testRule\(\) has parameter (.*?) with no value type specified in iterable type array#'
-            path: tests/Rules

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,10 +2,10 @@ includes:
     - config/extension.neon
 
 parameters:
-    type_coverage:
-        return_type: 99
-        param_type: 99
-        property_type: 99
+#    type_coverage:
+#        return_type: 99
+#        param_type: 99
+#        property_type: 99
 
     level: 8
 

--- a/src/ClassMethodCallReferenceResolver.php
+++ b/src/ClassMethodCallReferenceResolver.php
@@ -39,7 +39,11 @@ final class ClassMethodCallReferenceResolver
 
         $methodCallReferences = [];
         foreach ($callerType->getReferencedClasses() as $referencedClass) {
-            $methodCallReferences[] = new MethodCallReference($referencedClass, $methodCall->name->toString(), $isLocal);
+            $methodCallReferences[] = new MethodCallReference(
+                $referencedClass,
+                $methodCall->name->toString(),
+                $isLocal
+            );
         }
 
         return $methodCallReferences;

--- a/src/ClassMethodCallReferenceResolver.php
+++ b/src/ClassMethodCallReferenceResolver.php
@@ -38,8 +38,8 @@ final class ClassMethodCallReferenceResolver
         }
 
         $methodCallReferences = [];
-        foreach ($callerType->getReferencedClasses() as $className) {
-            $methodCallReferences[] = new MethodCallReference($className, $methodCall->name->toString(), $isLocal);
+        foreach ($callerType->getReferencedClasses() as $referencedClass) {
+            $methodCallReferences[] = new MethodCallReference($referencedClass, $methodCall->name->toString(), $isLocal);
         }
 
         return $methodCallReferences;

--- a/src/Collectors/Callable_/AttributeCallableCollector.php
+++ b/src/Collectors/Callable_/AttributeCallableCollector.php
@@ -8,11 +8,9 @@ use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\ArrayItem;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
-use PHPStan\Type\Constant\ConstantStringType;
 use TomasVotruba\UnusedPublic\Configuration;
 use TomasVotruba\UnusedPublic\ValueObject\ClassAndMethodArrayExprs;
 
@@ -53,8 +51,9 @@ final readonly class AttributeCallableCollector implements Collector
             }
 
             $classType = $scope->getType($classAndMethodArrayExprs->getClassExpr());
-            if ($classType instanceof ConstantStringType) {
-                $className = $classType->getValue();
+            if (count($classType->getConstantStrings()) === 1) {
+                $className = $classType->getConstantStrings()[0]
+                    ->getValue();
             } else {
                 continue;
             }
@@ -81,14 +80,6 @@ final readonly class AttributeCallableCollector implements Collector
 
         $array = $firstArg->value;
         if (count($array->items) !== 2) {
-            return null;
-        }
-
-        if (! $array->items[0] instanceof ArrayItem) {
-            return null;
-        }
-
-        if (! $array->items[1] instanceof ArrayItem) {
             return null;
         }
 

--- a/src/Collectors/Callable_/CallUserFuncCollector.php
+++ b/src/Collectors/Callable_/CallUserFuncCollector.php
@@ -56,26 +56,24 @@ final readonly class CallUserFuncCollector implements Collector
         }
 
         $callableType = $scope->getType($args[0]->value);
-        if (count($callableType->getConstantArrays()) !== 1) {
-            return null;
-        }
-
-        $typeAndMethodNames = $callableType->getConstantArrays()[0]
-            ->findTypeAndMethodNames();
-        if ($typeAndMethodNames === []) {
-            return null;
-        }
 
         $classMethodReferences = [];
-        foreach ($typeAndMethodNames as $typeAndMethodName) {
-            if ($typeAndMethodName->isUnknown()) {
+        foreach ($callableType->getConstantArrays() as $constantArray) {
+            $typeAndMethodNames = $constantArray->findTypeAndMethodNames();
+            if ($typeAndMethodNames === []) {
                 continue;
             }
 
-            $objectClassNames = $typeAndMethodName->getType()
-                ->getObjectClassNames();
-            foreach ($objectClassNames as $objectClassName) {
-                $classMethodReferences[] = $objectClassName . '::' . $typeAndMethodName->getMethod();
+            foreach ($typeAndMethodNames as $typeAndMethodName) {
+                if ($typeAndMethodName->isUnknown()) {
+                    continue;
+                }
+
+                $objectClassNames = $typeAndMethodName->getType()
+                    ->getObjectClassNames();
+                foreach ($objectClassNames as $objectClassName) {
+                    $classMethodReferences[] = $objectClassName . '::' . $typeAndMethodName->getMethod();
+                }
             }
         }
 

--- a/src/Collectors/Callable_/CallUserFuncCollector.php
+++ b/src/Collectors/Callable_/CallUserFuncCollector.php
@@ -10,7 +10,6 @@ use PhpParser\Node\Expr\FuncCall;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
-use PHPStan\Type\Constant\ConstantArrayType;
 use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
@@ -57,11 +56,12 @@ final readonly class CallUserFuncCollector implements Collector
         }
 
         $callableType = $scope->getType($args[0]->value);
-        if (! $callableType instanceof ConstantArrayType) {
+        if (count($callableType->getConstantArrays()) !== 1) {
             return null;
         }
 
-        $typeAndMethodNames = $callableType->findTypeAndMethodNames();
+        $typeAndMethodNames = $callableType->getConstantArrays()[0]
+            ->findTypeAndMethodNames();
         if ($typeAndMethodNames === []) {
             return null;
         }

--- a/src/Collectors/FormTypeClassCollector.php
+++ b/src/Collectors/FormTypeClassCollector.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace TomasVotruba\UnusedPublic\Collectors;
 
 use PhpParser\Node;
-use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
-use PHPStan\Type\Constant\ConstantStringType;
 use TomasVotruba\UnusedPublic\Configuration;
 
 /**
@@ -47,10 +46,10 @@ final readonly class FormTypeClassCollector implements Collector
         }
 
         $valueType = $scope->getType($node->value);
-        if (! $valueType instanceof ConstantStringType) {
+        if (count($valueType->getConstantStrings()) !== 1) {
             return null;
         }
 
-        return [$valueType->getValue()];
+        return [$valueType->getConstantStrings()[0]->getValue()];
     }
 }

--- a/src/Collectors/PublicClassLikeConstCollector.php
+++ b/src/Collectors/PublicClassLikeConstCollector.php
@@ -56,7 +56,7 @@ final readonly class PublicClassLikeConstCollector implements Collector
             $constantNames[] = [$classReflection->getName(), $constConst->name->toString(), $node->getLine()];
         }
 
-        if ([] === $constantNames) {
+        if ($constantNames === []) {
             return null;
         }
 

--- a/src/MethodTypeDetector.php
+++ b/src/MethodTypeDetector.php
@@ -41,6 +41,7 @@ final class MethodTypeDetector
         }
 
         $extendedMethodReflection = $classReflection->getMethod($classMethod->name->toString(), $scope);
+        // @phpstan-ignore phpstanApi.instanceofAssumption, phpstanApi.class
         if ($extendedMethodReflection instanceof PhpMethodReflection || $extendedMethodReflection instanceof ResolvedMethodReflection) {
             return $extendedMethodReflection->getDeclaringTrait() instanceof ClassReflection;
         }

--- a/src/Rules/UnusedPublicClassConstRule.php
+++ b/src/Rules/UnusedPublicClassConstRule.php
@@ -70,7 +70,7 @@ final readonly class UnusedPublicClassConstRule implements Rule
                 if ($declarationGroup === null) {
                     continue;
                 }
-                
+
                 foreach ($declarationGroup as [$className, $constantName, $line]) {
                     if ($this->isClassConstantUsed(
                         $className,

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/SkipPublicCallbackMethod.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/Fixture/SkipPublicCallbackMethod.php
@@ -18,5 +18,6 @@ final class SkipPublicCallbackMethod
 
 function doFoo()
 {
-    call_user_func([SkipPublicCallbackMethod::class, 'runHere']);
+    $object = new SkipPublicCallbackMethod();
+    call_user_func([$object, 'runHere']);
 }

--- a/tests/Rules/LocalOnlyPublicClassMethodRule/LocalOnlyPublicClassMethodRuleTest.php
+++ b/tests/Rules/LocalOnlyPublicClassMethodRule/LocalOnlyPublicClassMethodRuleTest.php
@@ -23,6 +23,10 @@ use TomasVotruba\UnusedPublic\Tests\Rules\LocalOnlyPublicClassMethodRule\Fixture
 
 final class LocalOnlyPublicClassMethodRuleTest extends RuleTestCase
 {
+    /**
+     * @param string[] $filePaths
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorMessagesWithLines): void
     {

--- a/tests/Rules/RelativeUnusedPublicClassMethodRule/RelativeUnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/RelativeUnusedPublicClassMethodRule/RelativeUnusedPublicClassMethodRuleTest.php
@@ -21,6 +21,10 @@ use TomasVotruba\UnusedPublic\Rules\RelativeUnusedPublicClassMethodRule;
 
 final class RelativeUnusedPublicClassMethodRuleTest extends RuleTestCase
 {
+    /**
+     * @param string[] $filePaths
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorMessagesWithLines): void
     {

--- a/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
+++ b/tests/Rules/UnusedPublicClassConstRule/UnusedPublicClassConstRuleTest.php
@@ -21,6 +21,10 @@ use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassConstRule\Fixture\Use
 
 final class UnusedPublicClassConstRuleTest extends RuleTestCase
 {
+    /**
+     * @param string[] $filePaths
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
     #[DataProvider('provideData')]
     #[DataProvider('provideDataFromBladeTemplates')]
     public function testRule(array $filePaths, array $expectedErrorMessagesWithLines): void

--- a/tests/Rules/UnusedPublicClassMethodRule/TemplatePathsTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/TemplatePathsTest.php
@@ -17,6 +17,10 @@ use TomasVotruba\UnusedPublic\Rules\UnusedPublicClassMethodRule;
 
 final class TemplatePathsTest extends RuleTestCase
 {
+    /**
+     * @param string[] $filePaths
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
     #[DataProvider('provideDataWithTwigTemplates')]
     #[DataProvider('provideDataWithBladeTemplates')]
     public function testRule(array $filePaths, array $expectedErrorMessagesWithLines): void

--- a/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
+++ b/tests/Rules/UnusedPublicClassMethodRule/UnusedPublicClassMethodRuleTest.php
@@ -28,6 +28,10 @@ use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicClassMethodRule\Source\Som
 
 final class UnusedPublicClassMethodRuleTest extends RuleTestCase
 {
+    /**
+     * @param string[] $filePaths
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
     #[DataProvider('provideData')]
     #[DataProvider('provideDataTests')]
     #[DataProvider('provideDataSymfony')]

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -23,6 +23,10 @@ use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture\UsedI
 
 final class UnusedPublicPropertyRuleTest extends RuleTestCase
 {
+    /**
+     * @param string[] $filePaths
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorMessagesWithLines
+     */
     #[DataProvider('provideData')]
     public function testRule(array $filePaths, array $expectedErrorMessagesWithLines): void
     {


### PR DESCRIPTION
Updates the code of this repository to be compatible with PHPStan 2.0, see the comments for more details

To work on this I had to disable the following dev dependencies: 

- rector/rector
- tomasvotruba/type-coverage
- symplify/phpstan-rules

Because they still depend on the old PHPStan 1.x. Once these dependencies get updated, this can be fully tested with them