### PR TITLE
Fix false positive on nullable public properties

### DIFF
--- a/src/Collectors/PublicPropertyFetchCollector.php
+++ b/src/Collectors/PublicPropertyFetchCollector.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Collectors\Collector;
 use PHPStan\Reflection\ClassReflection;
+use PHPStan\Type\TypeCombinator;
 use TomasVotruba\UnusedPublic\ClassTypeDetector;
 use TomasVotruba\UnusedPublic\Configuration;
 
@@ -59,6 +60,7 @@ final readonly class PublicPropertyFetchCollector implements Collector
 
         $result = [];
         $propertyFetcherType = $scope->getType($node->var);
+        $propertyFetcherType = TypeCombinator::removeNull($propertyFetcherType);
         foreach ($propertyFetcherType->getObjectClassReflections() as $classReflection) {
             $propertyName = $node->name->toString();
 

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/NullableProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/NullableProperty.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\PublicPropertyClass;
+
+class NullableProperty
+{
+    public function getBar(): ?PublicPropertyClass
+    {
+        if (rand(0, 1)) {
+            return null;
+        }
+        return new PublicPropertyClass();
+    }
+
+    public function doFoo(self $foo)
+    {
+        $x = $foo->getBar();
+        echo $x->property;
+    }
+}

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -136,6 +136,7 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
             __DIR__ . '/Fixture/StaticUsedInUnionA.php', __DIR__ . '/Fixture/StaticUsedInUnionB.php', __DIR__ . '/Source/StaticUsedInUnion.php'],
             [],
         ];
+        yield [[__DIR__ . '/Fixture/NullableProperty.php', __DIR__ . '/Source/PublicPropertyClass.php'], []];
 
     }
 


### PR DESCRIPTION
before this PR a false positive was reported when a public property was used, but the code did not explicitly eliminate a possible `null` value from a union