### PR TITLE
don't warn on properties which are part of an interface

### DIFF
--- a/src/Collectors/PublicPropertyCollector.php
+++ b/src/Collectors/PublicPropertyCollector.php
@@ -104,6 +104,13 @@ final readonly class PublicPropertyCollector implements Collector
         }
 
         $parentClassReflection = $classReflection->getParentClass();
+
+        foreach ($classReflection->getInterfaces() as $interface) {
+            if ($interface->hasProperty($propertyName)) {
+                return true;
+            }
+        }
+
         if (! $parentClassReflection instanceof ClassReflection) {
             return false;
         }

--- a/tests/Rules/UnusedPublicPropertyRule/Fixture/PropertyFromInterfaces.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Fixture/PropertyFromInterfaces.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Fixture;
+
+use TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source\InterfaceWithProperty;
+
+class PropertyFromInterfaces implements InterfaceWithProperty
+{
+    public string $prop = 'value';
+}
+
+function func(): ?InterfaceWithProperty
+{
+    return rand(0, 1) == 1 ? new PropertyFromInterfaces() : null;
+}
+
+$i = func();
+echo $i?->prop;

--- a/tests/Rules/UnusedPublicPropertyRule/Source/InterfaceWithProperty.php
+++ b/tests/Rules/UnusedPublicPropertyRule/Source/InterfaceWithProperty.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\UnusedPublic\Tests\Rules\UnusedPublicPropertyRule\Source;
+
+interface InterfaceWithProperty
+{
+    public string $prop {get; }
+}

--- a/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
+++ b/tests/Rules/UnusedPublicPropertyRule/UnusedPublicPropertyRuleTest.php
@@ -138,6 +138,9 @@ final class UnusedPublicPropertyRuleTest extends RuleTestCase
         ];
         yield [[__DIR__ . '/Fixture/NullableProperty.php', __DIR__ . '/Source/PublicPropertyClass.php'], []];
 
+        if (PHP_VERSION_ID >= 80400) {
+            yield 'foo' => [[__DIR__ . '/Fixture/PropertyFromInterfaces.php'], []];
+        }
     }
 
     /**


### PR DESCRIPTION
with PHP 8.4, interfaces can declare properties, so we should take that into account