### PR TITLE
chore: allow webmozart/assert ^2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^8.2",
         "phpstan/phpstan": "^2.1",
-        "webmozart/assert": "^1.12",
+        "webmozart/assert": "^1.12 || ^2.0",
         "nikic/php-parser": "^5.6"
     },
     "require-dev": {


### PR DESCRIPTION
There is no breaking change affecting this project :https://github.com/webmozarts/assert/blob/master/CHANGELOG.md#200


Linked to https://github.com/symplify/phpstan-rules/pull/253 to have version 2 locally installed because they reference each other.