### PR TITLE
Build downgraded release into anywherephp/unused-public repository

### DIFF
--- a/.github/workflows/downgraded_release.yaml
+++ b/.github/workflows/downgraded_release.yaml
@@ -2,6 +2,8 @@ name: Downgraded Release
 
 on:
     push:
+        branches:
+            - main
         tags:
             - '*'
 
@@ -10,7 +12,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: "actions/checkout@v2"
+            -   uses: "actions/checkout@v5"
+                with:
+                    token: ${{ secrets.WORKFLOWS_TOKEN || github.token }}
 
             -
                 uses: "shivammathur/setup-php@v2"
@@ -28,22 +32,48 @@ jobs:
             -   run: cp build/composer-php-74.json composer.json
 
             # clear the dev files
-            -   run: rm -rf build .github tests stubs ecs.php phpstan.neon phpunit.xml composer-dependency-analyser.php
+            -   run: rm -rf build .github tests stubs ecs.php phpstan.neon phpunit.xml composer-dependency-analyser.php rector.php
+
+            # clone the remote repository, so we can commit on top of its history and push without --force
+            # inspired by https://github.com/easy-coding-standard/ecs-src/blob/main/.github/workflows/buid_release.yaml
+            -
+                uses: "actions/checkout@v5"
+                with:
+                    repository: anywherephp/unused-public
+                    path: remote-repository
+                    token: ${{ secrets.WORKFLOWS_TOKEN }}
+
+            # remove remote files, to avoid piling up dead code in remote repository
+            -   run: rm -rf remote-repository/src remote-repository/config remote-repository/.github
+
+            # copy the downgraded code to the remote repository (skip dev-only files)
+            -   run: rsync -a --exclude .git --exclude remote-repository --exclude vendor --exclude composer.lock --exclude .idea --exclude .phpunit.cache ./ remote-repository/
 
             # setup git user
             -
+                working-directory: remote-repository
                 run: |
-                    git config user.email "action@github.com"
-                    git config user.name "GitHub Action"
+                    git config user.email "tomas@getrector.org"
+                    git config user.name "rector-bot"
 
-            # publish to the same repository with a new tag
+            # publish to remote repository without tag
             -
-                name: "Tag Downgraded Code"
+                name: "Push Downgraded Code - branch"
+                working-directory: remote-repository
+                if: "!startsWith(github.ref, 'refs/tags/')"
                 run: |
-                    # separate a "git add" to add untracked (new) files too
                     git add --all
-                    git commit -m "release PHP 7.4 downgraded"
+                    git commit -m "Updated UnusedPublic to commit ${{ github.event.after }}"
+                    git push --quiet origin main
 
-                    # force push tag, so there is only 1 version
-                    git tag "${GITHUB_REF#refs/tags/}" --force
-                    git push origin "${GITHUB_REF#refs/tags/}" --force
+            # publish to remote repository with tag
+            -
+                name: "Push Downgraded Code - tag"
+                working-directory: remote-repository
+                if: "startsWith(github.ref, 'refs/tags/')"
+                run: |
+                    git add --all
+                    git commit --allow-empty -m "UnusedPublic ${GITHUB_REF#refs/tags/}"
+                    git push --quiet origin main
+                    git tag "${GITHUB_REF#refs/tags/}" -m "${GITHUB_REF#refs/tags/}"
+                    git push --quiet origin "${GITHUB_REF#refs/tags/}"


### PR DESCRIPTION
Adapts the downgraded-release workflow to the approach from [rectorphp/swiss-knife@7c6d7c5](https://github.com/rectorphp/swiss-knife/commit/7c6d7c5937f02bd0e44dffacd637ac8ffa3b2ee2).

Instead of force-tagging the PHP 7.4 build onto this same repository, the build is now pushed to a dedicated **`anywherephp/unused-public`** repository (created, seeded with an empty `.gitignore` so the checkout/push works).

## Changes
- Trigger on `push` to `main` **and** tags
- `actions/checkout@v5`, token `secrets.WORKFLOWS_TOKEN || github.token`
- Clone target `anywherephp/unused-public` into `remote-repository`, wipe its `src`/`config`/`.github`, `rsync` the downgraded code in, commit on top of its history and push without `--force`
- Separate steps for branch push (`main`) vs tag push
- Commit as `rector-bot <tomas@getrector.org>`

## Notes
- **No `*.sh` files existed** to remove/inline — unused-public is a library, not a scoped phar tool, so the `prefix-code.sh` / php-scoper step from swiss-knife does not apply.
- `rsync` excludes dev-only `vendor`, `composer.lock`, `.idea`, `.phpunit.cache` so the released library ships clean (swiss-knife shipped `vendor` because its phar needs it).
- Requires a `WORKFLOWS_TOKEN` secret with write access to `anywherephp/unused-public` for the cross-repo push.